### PR TITLE
미디어위키 내장 기능을 사용한 특정 이름공간 검색 차단

### DIFF
--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -260,6 +260,13 @@ require_once "$IP/extensions/Description2/Description2.php";
 ## OpenGraphMeta
 require_once( "$IP/extensions/OpenGraphMeta/OpenGraphMeta.php" );
 
+## Prevent Search for some namespaces
+$wgNamespaceRobotPolicies = array(
+    NS_TALK => 'noindex,nofollow',
+    NS_USER_TALK => 'noindex,nofollow',
+    NS_PROJECT_TALK => 'noindex,nofollow',
+);
+
 ## SimpleMathJax
 require_once "$IP/extensions/SimpleMathJax/SimpleMathJax.php";
 

--- a/www/robots.txt
+++ b/www/robots.txt
@@ -4,8 +4,5 @@ Disallow: /w/api.php
 Disallow: /api.php
 Disallow: /w/Special:*
 Disallow: /w/%ED%8A%B9%EC%88%98:*
-Disallow: /w/%ED%8E%98%EB%AF%B8%EC%9C%84%ED%82%A4%ED%86%A0%EB%A1%A0:*
-Disallow: /w/%ED%86%A0%EB%A1%A0:*
-Disallow: /w/%EC%82%AC%EC%9A%A9%EC%9E%90%ED%86%A0%EB%A1%A0:*
 
 sitemap:https://femiwiki.com/sitemap/sitemap-index-femiwiki.xml


### PR DESCRIPTION
사실 이건 안 받아들이셔도 상관 없는 PR이긴 한데요, 일단 날려 둡니다.

미디어위키가 지원하는 [설정](https://www.mediawiki.org/wiki/Manual:$wgNamespaceRobotPolicies)을 이용해 인덱스를 차단합니다. [토론:김여사](https://femiwiki.com/index.php?title=%ED%86%A0%EB%A1%A0:%EA%B9%80%EC%97%AC%EC%82%AC&action=info)의 "로봇에 의한 색인: 허용됨"이 "로봇에 의한 색인: 불허됨"으로 바뀌면 제대로 설정이 적용된 것입니다.