### PR TITLE
다면분류 확장기능 업그레이드

### DIFF
--- a/www/extensions/FacetedCategory/extension.json
+++ b/www/extensions/FacetedCategory/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "FacetedCategory",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"author": [
 		"Lens"
 	],

--- a/www/extensions/FacetedCategory/i18n/en.json
+++ b/www/extensions/FacetedCategory/i18n/en.json
@@ -4,5 +4,6 @@
 	}, 
 	"facetedcategories": "Faceted Categories",
 	"facetedcategory-desc": "Add [[Special:FacetedCategories]]",
-	"faceted_category_search_for": "category name:"
+	"faceted_category_search_for": "category name:",
+	"faceted_category_match_exactly": "Match exactly"
 }

--- a/www/extensions/FacetedCategory/i18n/ko.json
+++ b/www/extensions/FacetedCategory/i18n/ko.json
@@ -4,5 +4,6 @@
 	},
 	"facetedcategories": "다면 분류 목록",
 	"facetedcategory-desc": "[[특수:다면분류]]를 추가합니다.",
-	"faceted_category_search_for": "다음 분류 보기:"
+	"faceted_category_search_for": "다음 분류 보기:",
+	"faceted_category_match_exactly": "정확히 일치하는 결과만 보기"
 }

--- a/www/extensions/FacetedCategory/includes/FacetedCategoryPager.php
+++ b/www/extensions/FacetedCategory/includes/FacetedCategoryPager.php
@@ -3,10 +3,12 @@ class FacetedCategoryPager extends AlphabeticPager {
 
 	protected $linkRenderer;
 
-	public $facetName;
-	public $facetMember;
+	private $facetName;
+	private $facetMember;
+	private $matchExactly;
+	private $including;
 
-	public function __construct( IContextSource $context, $facetName, $facetMember, PageLinkRenderer $linkRenderer
+	public function __construct( IContextSource $context, $facetName, $facetMember, $matchExactly, PageLinkRenderer $linkRenderer, $including
 	) {
 		parent::__construct( $context );
 		$facetName = str_replace( ' ', '_', $facetName );
@@ -16,6 +18,12 @@ class FacetedCategoryPager extends AlphabeticPager {
 			$this->facetName = $facetName;
 		if($facetMember !== '')
 			$this->facetMember = $facetMember;
+		if($matchExactly !== '')
+			$this->matchExactly = $matchExactly;
+		if($including !== '')
+			$this->including = $including;
+
+		if($including) $this->setLimit(200);
 
 		$this->linkRenderer = $linkRenderer;
 	}
@@ -28,13 +36,18 @@ class FacetedCategoryPager extends AlphabeticPager {
 			'options' => [ 'USE INDEX' => 'cat_title' ],
 		];
 
-		if ($this->facetName!=='' && $this->facetMember!=='') {
+		if($this->matchExactly) {
+			if ($this->facetName!='' && $this->facetMember!='') {
+				$query['conds'][] = 'cat_title' . $this->mDb->buildLike($this->facetName.'/'.$this->facetMember);
+			} elseif ($this->facetName!='' && $this->facetMember=='') {
+				$query['conds'][] = 'cat_title' . $this->mDb->buildLike($this->facetName.'/',$this->mDb->anyString());
+			} elseif ($this->facetName=='' && $this->facetMember!='') {
+				$query['conds'][] = 'cat_title' . $this->mDb->buildLike($this->mDb->anyString(),'/'.$this->facetMember);
+			} else {
+				$query['conds'][] = 'cat_title' . $this->mDb->buildLike($this->mDb->anyString(),'/',$this->mDb->anyString());
+			}
+		} else {
 			$query['conds'][] = 'cat_title' . $this->mDb->buildLike($this->mDb->anyString(),$this->facetName,$this->mDb->anyString(),'/',$this->mDb->anyString(),$this->facetMember,$this->mDb->anyString());
-			//$query['conds'][] = 'cat_title' . $this->mDb->buildLike('$this->facetMember.'/'.$this->facetMember');
-		} elseif ($this->facetName!=='' && $this->facetMember==='') {
-			$query['conds'][] = 'cat_title' . $this->mDb->buildLike($this->mDb->anyString(),$this->facetName,$this->mDb->anyString(),'/',$this->mDb->anyString());
-		} elseif ($this->facetName==='' && $this->facetMember!=='') {
-			$query['conds'][] = 'cat_title' . $this->mDb->buildLike($this->mDb->anyString(),'/',$this->mDb->anyString(),$this->facetMember,$this->mDb->anyString());
 		}
 
 		return $query;
@@ -72,10 +85,11 @@ class FacetedCategoryPager extends AlphabeticPager {
 
 		$count = $this->msg( 'nmembers' )->numParams( $result->cat_pages )->escaped();
 		return Html::rawElement( 'li', null, $this->getLanguage()->specialList( $link, $count ) ) . "\n";
+
 	}
 
-	public function getStartForm( $facetName, $facetMember ) {
-		return Xml::tags(
+	public function getStartForm( $facetName, $facetMember, $matchExactly ) {
+		return $this->including ? '':Xml::tags(
 			'form',
 			[ 'method' => 'get', 'action' => wfScript() ],
 			Html::hidden( 'title', $this->getTitle()->getPrefixedText() ) .
@@ -92,7 +106,10 @@ class FacetedCategoryPager extends AlphabeticPager {
 				Html::submitButton(
 					$this->msg( 'categories-submit' )->text(),
 					[], [ 'mw-ui-progressive' ]
-				)
+				) .
+				' ' .
+				Xml::checkLabel(
+					$this->msg( 'faceted_category_match_exactly' ), 'matchExactly', 'matchExactly', $matchExactly, [] )
 			)
 		);
 	}

--- a/www/extensions/FacetedCategory/specials/SpecialFacetedCategories.php
+++ b/www/extensions/FacetedCategory/specials/SpecialFacetedCategories.php
@@ -1,39 +1,11 @@
 <?php
-/**
- * Implements Special:Categories
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * http://www.gnu.org/copyleft/gpl.html
- *
- * @file
- * @ingroup SpecialPage
- */
 
-/**
- * @ingroup SpecialPage
- */
-class SpecialFacetedCategories extends SpecialPage {
+class SpecialFacetedCategories extends IncludableSpecialPage {
 
 	protected $linkRenderer = null;
 
 	public function __construct() {
 		parent::__construct( 'FacetedCategories' );
-
-		// Since we don't control the constructor parameters, we can't inject services that way.
-		// Instead, we initialize services in the execute() method, and allow them to be overridden
-		// using the initServices() method.
 	}
     
     public function setPageLinkRenderer(
@@ -42,13 +14,14 @@ class SpecialFacetedCategories extends SpecialPage {
         $this->linkRenderer = $linkRenderer;
     }
     
-private function initServices() {
-    if ( !$this->linkRenderer ) {
-        $lang = $this->getContext()->getLanguage();
-        $titleFormatter = new MediaWikiTitleCodec( $lang, GenderCache::singleton() );
-        $this->linkRenderer = new MediaWikiPageLinkRenderer( $titleFormatter );
-    }
-}
+	private function initServices() {
+	    if ( !$this->linkRenderer ) {
+	        $lang = $this->getContext()->getLanguage();
+	        $titleFormatter = new MediaWikiTitleCodec( $lang, GenderCache::singleton() );
+	        $this->linkRenderer = new MediaWikiPageLinkRenderer( $titleFormatter );
+	    }
+	}
+
 
 	public function execute( $par ) {
 		$this->initServices();
@@ -57,24 +30,31 @@ private function initServices() {
 		$this->outputHeader();
 		$this->getOutput()->allowClickjacking();
 
-		$facetName = $this->getRequest()->getText( 'facetName', $par );
-		$facetMember = $this->getRequest()->getText( 'facetMember', $par );
+		$slash = strpos($par,'/');
+		$left = $slash===false?$par:substr($par,0,$slash);
+		$right = $slash===false?'':substr($par,$slash+1,strlen($par)-1);
+		
+		$facetName = $this->getRequest()->getText( 'facetName', $left );
+		$facetMember = $this->getRequest()->getText( 'facetMember', $right );
+		$matchExactly = $this->getRequest()->getBool( 'matchExactly', true );
 
 		$cap = new FacetedCategoryPager(
 			$this->getContext(),
 			$facetName,
 			$facetMember,
-			$this->linkRenderer
+			$matchExactly,
+			$this->linkRenderer,
+			$this->including()
 		);
 		$cap->doQuery();
 
 		$this->getOutput()->addHTML(
 			Html::openElement( 'div', [ 'class' => 'mw-spcontent' ] ) .
-				$this->msg( 'categoriespagetext', $cap->getNumRows() )->parseAsBlock() .
-				$cap->getStartForm( $facetName, $facetMember ) .
-				$cap->getNavigationBar() .
+				($this->including()?'':$this->msg( 'categoriespagetext', $cap->getNumRows() )->parseAsBlock()) .
+				$cap->getStartForm( $facetName, $facetMember, $matchExactly ) .
+				($this->including()?'':$cap->getNavigationBar()) .
 				'<ul>' . $cap->getBody() . '</ul>' .
-				$cap->getNavigationBar() .
+				($this->including()?'':$cap->getNavigationBar()) .
 				Html::closeElement( 'div' )
 		);
 	}


### PR DESCRIPTION
<ol>
<li><dl><di><code>[[특수:다면분류]]</code> 특수 문서 변경사항</di>
<dd><ul><li> 검색어와 '정확히 일치하는 결과만 보기' 옵션 추가</li><li><code>[[특수:다면분류/검색어]]</code> 형식으로 전달받은 `검색어`로 빈 폼 자동 채워주기 제공</li></dd></li>
<li><dl><di><code>{{특수:다면분류}}</code> 끼워넣기 추가</di><dd><ul><li>끼워넣어질 경우 네비게이션바가 보이지 않고 최대 200개의 결과만 표시됩니다.</li><li><code>{{특수:다면분류/종류}}</code>혹은 <code>{{특수:다면분류//페미니즘}}</code>과 같은 입력도 가능합니다.</li></ul></dd></li>
</ol>