### PR TITLE
Modify skin, and install AbuseFilter and Realnames(modified)

### DIFF
--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -38,7 +38,7 @@ $wgEnableCanonicalServerLink = true;
 ## The URL path to static resources (images, scripts, etc.)
 $wgResourceBasePath = $wgScriptPath;
 
-$wgStyleVersion = '20170710_0';
+$wgStyleVersion = '20170715_0';
 $wgResourceLoaderMaxage = array(
     'versioned' => array(
         // Squid/Varnish but also any other public proxy cache between the client and MediaWiki
@@ -258,6 +258,10 @@ wfLoadExtension('Thanks');
 ## Scribunto
 require_once "$IP/extensions/Scribunto/Scribunto.php";
 $wgScribuntoDefaultEngine = 'luastandalone';
+
+## Realnames
+require_once("$IP/extensions/Realnames/Realnames.php");
+$wgRealnamesLinkStyle = "femiwiki";
 
 ## Flow
 require_once "$IP/extensions/Flow/Flow.php";

--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -38,7 +38,7 @@ $wgEnableCanonicalServerLink = true;
 ## The URL path to static resources (images, scripts, etc.)
 $wgResourceBasePath = $wgScriptPath;
 
-$wgStyleVersion = '20170715_0';
+$wgStyleVersion = '20170723_0';
 $wgResourceLoaderMaxage = array(
     'versioned' => array(
         // Squid/Varnish but also any other public proxy cache between the client and MediaWiki

--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -141,19 +141,16 @@ define("NS_BBS", 3906);
 define("NS_BBS_TALK", 3907);
 $wgExtraNamespaces[NS_BBS] = "게시판";
 $wgExtraNamespaces[NS_BBS_TALK] = "게시판토론";
-$wgContentNamespaces[] = NS_BBS;
 
 ## BBS (Legacy)
 define("NS_BBSFREE", 3902);
 define("NS_BBSFREE_TALK", 3903);
 $wgExtraNamespaces[NS_BBSFREE] = "자유게시판";
 $wgExtraNamespaces[NS_BBSFREE_TALK] = "자유게시판토론";
-$wgContentNamespaces[] = NS_BBSFREE;
 define("NS_BBSINTRO", 3904);
 define("NS_BBSINTRO_TALK", 3905);
 $wgExtraNamespaces[NS_BBSINTRO] = "가입인사게시판";
 $wgExtraNamespaces[NS_BBSINTRO_TALK] = "가입인사게시판토론";
-$wgContentNamespaces[] = NS_BBSINTRO;
 
 ## Misc. ns settings
 $wgNamespacesWithSubpages[NS_TEMPLATE] = true;
@@ -295,6 +292,16 @@ $wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
 $wgDefaultUserOptions['wikieditor-preview'] = 1;
 $wgDefaultUserOptions['wikieditor-publish'] = 1;
 
+## AbuseFilter
+wfLoadExtension( 'AbuseFilter' );
+$wgGroupPermissions['sysop']['abusefilter-modify'] = true;
+$wgGroupPermissions['*']['abusefilter-log-detail'] = true;
+$wgGroupPermissions['*']['abusefilter-view'] = true;
+$wgGroupPermissions['*']['abusefilter-log'] = true;
+$wgGroupPermissions['sysop']['abusefilter-private'] = true;
+$wgGroupPermissions['sysop']['abusefilter-modify-restricted'] = true;
+$wgGroupPermissions['sysop']['abusefilter-revert'] = true;
+
 ## UserMerge
 wfLoadExtension('UserMerge');
 
@@ -341,4 +348,3 @@ $wgHTMLTagsAttributes['iframe'] = array('src', 'class', 'style');
 # Misc.
 $wgShowExceptionDetails = ('HOST' != 'femiwiki.com');
 $wgDebugToolbar = ('HOST' != 'femiwiki.com');
-

--- a/www/extensions/ExtendedSpecialPagesForFemiwiki/specials/SpecialOrderedWhatlinkshere.php
+++ b/www/extensions/ExtendedSpecialPagesForFemiwiki/specials/SpecialOrderedWhatlinkshere.php
@@ -1,203 +1,241 @@
 <?php
 class SpecialOrderedWhatlinkshere extends SpecialWhatLinksHere {
 
-    function showIndirectLinks( $level, $target, $limit, $from = 0, $back = 0 ) {
-        $out = $this->getOutput();
-        $dbr = wfGetDB( DB_SLAVE );
- 
-        $hidelinks = $this->opts->getValue( 'hidelinks' );
-        $hideredirs = $this->opts->getValue( 'hideredirs' );
-        $hidetrans = $this->opts->getValue( 'hidetrans' );
-        $hideimages = $target->getNamespace() != NS_FILE || $this->opts->getValue( 'hideimages' );
- 
-        $fetchlinks = ( !$hidelinks || !$hideredirs );
- 
-        // Build query conds in concert for all three tables...
-        $conds['pagelinks'] = [
-            'pl_namespace' => $target->getNamespace(),
-            'pl_title' => $target->getDBkey(),
-        ];
-        $conds['templatelinks'] = [
-            'tl_namespace' => $target->getNamespace(),
-            'tl_title' => $target->getDBkey(),
-        ];
-        $conds['imagelinks'] = [
-            'il_to' => $target->getDBkey(),
-        ];
- 
-        $namespace = $this->opts->getValue( 'namespace' );
-        $invert = $this->opts->getValue( 'invert' );
-        $nsComparison = ( $invert ? '!= ' : '= ' ) . $dbr->addQuotes( $namespace );
-        if ( is_int( $namespace ) ) {
-            $conds['pagelinks'][] = "pl_from_namespace $nsComparison";
-            $conds['templatelinks'][] = "tl_from_namespace $nsComparison";
-            $conds['imagelinks'][] = "il_from_namespace $nsComparison";
-        }
- 
-        if ( $from ) {
-            $conds['templatelinks'][] = "tl_from >= $from";
-            $conds['pagelinks'][] = "pl_from >= $from";
-            $conds['imagelinks'][] = "il_from >= $from";
-        }
- 
-        if ( $hideredirs ) {
-            $conds['pagelinks']['rd_from'] = null;
-        } elseif ( $hidelinks ) {
-            $conds['pagelinks'][] = 'rd_from is NOT NULL';
-        }
- 
-        $queryFunc = function ( IDatabase $dbr, $table, $fromCol ) use (
-            $conds, $target, $limit
-        ) {
-            // Read an extra row as an at-end check
-            $queryLimit = $limit + 1;
-            $on = [
-                "rd_from = $fromCol",
-                'rd_title' => $target->getDBkey(),
-                'rd_interwiki = ' . $dbr->addQuotes( '' ) . ' OR rd_interwiki IS NULL'
-            ];
-            $on['rd_namespace'] = $target->getNamespace();
-            // Inner LIMIT is 2X in case of stale backlinks with wrong namespaces
-            $subQuery = $dbr->selectSQLText(
-                [ $table, 'redirect', 'page' ],
-                [ $fromCol, 'rd_from' ],
-                $conds[$table],
-                __CLASS__ . '::showIndirectLinks',
-                // Force JOIN order per T106682 to avoid large filesorts
-                [ 'ORDER BY' => $fromCol, 'LIMIT' => 2 * $queryLimit, 'STRAIGHT_JOIN' ],
-                [
-                    'page' => [ 'INNER JOIN', "$fromCol = page_id" ],
-                    'redirect' => [ 'LEFT JOIN', $on ]
-                ]
-            );
-            return $dbr->select(
-                [ 'page', 'temp_backlink_range' => "($subQuery)" ],
-                [ 'page_id', 'page_namespace', 'page_title', 'rd_from', 'page_is_redirect' ],
-                [],
-                __CLASS__ . '::showIndirectLinks',
-                [ 'ORDER BY' => 'page_title', 'LIMIT' => $queryLimit ],
-                [ 'page' => [ 'INNER JOIN', "$fromCol = page_id" ] ]
-            );
-        };
- 
-        if ( $fetchlinks ) {
-            $plRes = $queryFunc( $dbr, 'pagelinks', 'pl_from' );
-        }
- 
-        if ( !$hidetrans ) {
-            $tlRes = $queryFunc( $dbr, 'templatelinks', 'tl_from' );
-        }
- 
-        if ( !$hideimages ) {
-            $ilRes = $queryFunc( $dbr, 'imagelinks', 'il_from' );
-        }
- 
-        if ( ( !$fetchlinks || !$plRes->numRows() )
-            && ( $hidetrans || !$tlRes->numRows() )
-            && ( $hideimages || !$ilRes->numRows() )
-        ) {
-            if ( 0 == $level ) {
-                if ( !$this->including() ) {
-                    $out->addHTML( $this->whatlinkshereForm() );
- 
-                    // Show filters only if there are links
-                    if ( $hidelinks || $hidetrans || $hideredirs || $hideimages ) {
-                        $out->addHTML( $this->getFilterPanel() );
-                    }
-                    $errMsg = is_int( $namespace ) ? 'nolinkshere-ns' : 'nolinkshere';
-                    $out->addWikiMsg( $errMsg, $this->target->getPrefixedText() );
-                    $out->setStatusCode( 404 );
-                }
-            }
- 
-            return;
-        }
- 
-        // Read the rows into an array and remove duplicates
-        // templatelinks comes second so that the templatelinks row overwrites the
-        // pagelinks row, so we get (inclusion) rather than nothing
-        if ( $fetchlinks ) {
-            foreach ( $plRes as $row ) {
-                $row->is_template = 0;
-                $row->is_image = 0;
-                $rows[$row->page_title] = $row;
-            }
-        }
-        if ( !$hidetrans ) {
-            foreach ( $tlRes as $row ) {
-                $row->is_template = 1;
-                $row->is_image = 0;
-                $rows[$row->page_title] = $row;
-            }
-        }
-        if ( !$hideimages ) {
-            foreach ( $ilRes as $row ) {
-                $row->is_template = 0;
-                $row->is_image = 1;
-                $rows[$row->page_title] = $row;
-            }
-        }
- 
-        // Sort by key and then change the keys to 0-based indices
-        ksort( $rows );
-        $rows = array_values( $rows );
- 
-        $numRows = count( $rows );
- 
-        // Work out the start and end IDs, for prev/next links
-        if ( $numRows > $limit ) {
-            // More rows available after these ones
-            // Get the ID from the last row in the result set
-            $nextId = $rows[$limit]->page_id;
-            // Remove undisplayed rows
-            $rows = array_slice( $rows, 0, $limit );
-        } else {
-            // No more rows after
-            $nextId = false;
-        }
-        $prevId = $from;
- 
-        // use LinkBatch to make sure, that all required data (associated with Titles)
-        // is loaded in one query
-        $lb = new LinkBatch();
-        foreach ( $rows as $row ) {
-            $lb->add( $row->page_namespace, $row->page_title );
-        }
-        $lb->execute();
- 
-        if ( $level == 0 ) {
-            if ( !$this->including() ) {
-                $out->addHTML( $this->whatlinkshereForm() );
-                $out->addHTML( $this->getFilterPanel() );
-                $out->addWikiMsg( 'linkshere', $this->target->getPrefixedText() );
- 
-                $prevnext = $this->getPrevNext( $prevId, $nextId );
-                $out->addHTML( $prevnext );
-            }
-        }
-        $out->addHTML( $this->listStart( $level ) );
-        foreach ( $rows as $row ) {
-            $nt = Title::makeTitle( $row->page_namespace, $row->page_title );
- 
-            if ( $row->rd_from && $level < 2 ) {
-                $out->addHTML( $this->listItem( $row, $nt, $target, true ) );
-                $this->showIndirectLinks(
-                    $level + 1,
-                    $nt,
-                    $this->getConfig()->get( 'MaxRedirectLinksRetrieved' )
-                );
-                $out->addHTML( Xml::closeElement( 'li' ) );
-            } else {
-                $out->addHTML( $this->listItem( $row, $nt, $target ) );
-            }
-        }
- 
-        $out->addHTML( $this->listEnd() );
- 
-        if ( $level == 0 ) {
-            if ( !$this->including() ) {
-                $out->addHTML( $prevnext );
-            }
-        }
-    }
+	function showIndirectLinks( $level, $target, $limit, $from = 0, $back = 0 ) {
+		$out = $this->getOutput();
+		$dbr = wfGetDB( DB_SLAVE );
+
+		$hidelinks = $this->opts->getValue( 'hidelinks' );
+		$hideredirs = $this->opts->getValue( 'hideredirs' );
+		$hidetrans = $this->opts->getValue( 'hidetrans' );
+		$hideimages = $target->getNamespace() != NS_FILE || $this->opts->getValue( 'hideimages' );
+
+		$fetchlinks = ( !$hidelinks || !$hideredirs );
+
+		// Build query conds in concert for all three tables...
+		$conds['pagelinks'] = [
+			'pl_namespace' => $target->getNamespace(),
+			'pl_title' => $target->getDBkey(),
+		];
+		$conds['templatelinks'] = [
+			'tl_namespace' => $target->getNamespace(),
+			'tl_title' => $target->getDBkey(),
+		];
+		$conds['imagelinks'] = [
+			'il_to' => $target->getDBkey(),
+		];
+
+		$namespace = $this->opts->getValue( 'namespace' );
+		$invert = $this->opts->getValue( 'invert' );
+		$nsComparison = ( $invert ? '!= ' : '= ' ) . $dbr->addQuotes( $namespace );
+		if ( is_int( $namespace ) ) {
+			$conds['pagelinks'][] = "pl_from_namespace $nsComparison";
+			$conds['templatelinks'][] = "tl_from_namespace $nsComparison";
+			$conds['imagelinks'][] = "il_from_namespace $nsComparison";
+		}
+
+		/*if ( $from ) {
+			$conds['templatelinks'][] = "tl_from >= $from";
+			$conds['pagelinks'][] = "pl_from >= $from";
+			$conds['imagelinks'][] = "il_from >= $from";
+		}*/
+
+		if ( $hideredirs ) {
+			$conds['pagelinks']['rd_from'] = null;
+		} elseif ( $hidelinks ) {
+			$conds['pagelinks'][] = 'rd_from is NOT NULL';
+		}
+
+		$queryFunc = function ( IDatabase $dbr, $table, $fromCol ) use (
+			$conds, $target, $limit
+		) {
+			// Read an extra row as an at-end check
+			$on = [
+				"rd_from = $fromCol",
+				'rd_title' => $target->getDBkey(),
+				'rd_interwiki = ' . $dbr->addQuotes( '' ) . ' OR rd_interwiki IS NULL'
+			];
+			$on['rd_namespace'] = $target->getNamespace();
+			// Inner LIMIT is 2X in case of stale backlinks with wrong namespaces
+			$subQuery = $dbr->selectSQLText(
+				[ $table, 'redirect', 'page' ],
+				[ $fromCol, 'rd_from' ],
+				$conds[$table],
+				__CLASS__ . '::showIndirectLinks',
+				// Force JOIN order per T106682 to avoid large filesorts
+				[ 'ORDER BY' => $fromCol, 'STRAIGHT_JOIN' ],
+				[
+					'page' => [ 'INNER JOIN', "$fromCol = page_id" ],
+					'redirect' => [ 'LEFT JOIN', $on ]
+				]
+			);
+			return $dbr->select(
+				[ 'page', 'temp_backlink_range' => "($subQuery)" ],
+				[ 'page_id', 'page_namespace', 'page_title', 'rd_from', 'page_is_redirect' ],
+				[],
+				__CLASS__ . '::showIndirectLinks',
+				[ 'ORDER BY' => 'page_title' ],
+				[ 'page' => [ 'INNER JOIN', "$fromCol = page_id" ] ]
+			);
+		};
+
+		if ( $fetchlinks ) {
+			$plRes = $queryFunc( $dbr, 'pagelinks', 'pl_from' );
+		}
+
+		if ( !$hidetrans ) {
+			$tlRes = $queryFunc( $dbr, 'templatelinks', 'tl_from' );
+		}
+
+		if ( !$hideimages ) {
+			$ilRes = $queryFunc( $dbr, 'imagelinks', 'il_from' );
+		}
+
+		if ( ( !$fetchlinks || !$plRes->numRows() )
+			&& ( $hidetrans || !$tlRes->numRows() )
+			&& ( $hideimages || !$ilRes->numRows() )
+		) {
+			if ( 0 == $level ) {
+				if ( !$this->including() ) {
+					$out->addHTML( $this->whatlinkshereForm() );
+
+					// Show filters only if there are links
+					if ( $hidelinks || $hidetrans || $hideredirs || $hideimages ) {
+						$out->addHTML( $this->getFilterPanel() );
+					}
+					$errMsg = is_int( $namespace ) ? 'nolinkshere-ns' : 'nolinkshere';
+					$out->addWikiMsg( $errMsg, $this->target->getPrefixedText() );
+					$out->setStatusCode( 404 );
+				}
+			}
+
+			return;
+		}
+
+		// Read the rows into an array and remove duplicates
+		// templatelinks comes second so that the templatelinks row overwrites the
+		// pagelinks row, so we get (inclusion) rather than nothing
+		if ( $fetchlinks ) {
+			foreach ( $plRes as $row ) {
+				$row->is_template = 0;
+				$row->is_image = 0;
+				$rows[$row->page_id] = $row;
+			}
+		}
+		if ( !$hidetrans ) {
+			foreach ( $tlRes as $row ) {
+				$row->is_template = 1;
+				$row->is_image = 0;
+				$rows[$row->page_id] = $row;
+			}
+		}
+		if ( !$hideimages ) {
+			foreach ( $ilRes as $row ) {
+				$row->is_template = 0;
+				$row->is_image = 1;
+				$rows[$row->page_id] = $row;
+			}
+		}
+
+		// Sort by key and then change the keys to 0-based indices
+		
+		
+		usort( $rows , function ($a, $b) use ($out) {
+			if(isset($a->page_title) && isset($b->page_title)){
+				return strcasecmp($a->page_title, $b->page_title);
+			}
+			else return 0;
+		} );
+		$rows = array_values( $rows );
+
+		$numRows = count( $rows );
+
+		// Work out the start and end IDs, for prev/next links
+		if ( $numRows-$from > $limit ) {
+			// More rows available after these ones
+			// Get the ID from the last row in the result set
+			$nextNumber = $from+$limit;
+			// Remove undisplayed rows
+			$rows = array_slice( $rows, $from, $limit );
+		} else {
+			// No more rows after
+			$nextNumber = false;
+			// Remove undisplayed rows
+			$rows = array_slice( $rows, $from );
+		}
+		$prevNumber = ($from == 0?null:$from-$limit);
+
+		// use LinkBatch to make sure, that all required data (associated with Titles)
+		// is loaded in one query
+		$lb = new LinkBatch();
+		foreach ( $rows as $row ) {
+			$lb->add( $row->page_namespace, $row->page_title );
+		}
+		$lb->execute();
+
+		if ( $level == 0 ) {
+			if ( !$this->including() ) {
+				$out->addHTML( $this->whatlinkshereForm() );
+				$out->addHTML( $this->getFilterPanel() );
+				$out->addWikiMsg( 'linkshere', $this->target->getPrefixedText() );
+
+				$prevnext = $this->getPrevNext( $prevNumber, $nextNumber );
+				$out->addHTML( $prevnext );
+			}
+		}
+		$out->addHTML( $this->listStart( $level ) );
+		foreach ( $rows as $row ) {
+			$nt = Title::makeTitle( $row->page_namespace, $row->page_title );
+
+			if ( $row->rd_from && $level < 2 ) {
+				$out->addHTML( $this->listItem( $row, $nt, $target, true ) );
+				$this->showIndirectLinks(
+					$level + 1,
+					$nt,
+					$this->getConfig()->get( 'MaxRedirectLinksRetrieved' )
+				);
+				$out->addHTML( Xml::closeElement( 'li' ) );
+			} else {
+				$out->addHTML( $this->listItem( $row, $nt, $target ) );
+			}
+		}
+
+		$out->addHTML( $this->listEnd() );
+
+		if ( $level == 0 ) {
+			if ( !$this->including() ) {
+				$out->addHTML( $prevnext );
+			}
+		}
+	}
+
+	function getPrevNext( $prevNumber, $nextNumber ) {
+		$currentLimit = $this->opts->getValue( 'limit' );
+		$prev = $this->msg( 'whatlinkshere-prev' )->numParams( $currentLimit )->escaped();
+		$next = $this->msg( 'whatlinkshere-next' )->numParams( $currentLimit )->escaped();
+
+		$changed = $this->opts->getChangedValues();
+		unset( $changed['target'] ); // Already in the request title
+
+		if ( null !== $prevNumber ) {
+			$overrides = [ 'from' => $prevNumber ];
+			$prev = $this->makeSelfLink( $prev, array_merge( $changed, $overrides ) );
+		}
+		if ( 0 != $nextNumber ) {
+			$overrides = [ 'from' => $nextNumber ];
+			$next = $this->makeSelfLink( $next, array_merge( $changed, $overrides ) );
+		}
+
+		$limitLinks = [];
+		$lang = $this->getLanguage();
+		foreach ( $this->limits as $limit ) {
+			$prettyLimit = htmlspecialchars( $lang->formatNum( $limit ) );
+			$overrides = [ 'limit' => $limit ];
+			$limitLinks[] = $this->makeSelfLink( $prettyLimit, array_merge( $changed, $overrides ) );
+		}
+
+		$nums = $lang->pipeList( $limitLinks );
+
+		return $this->msg( 'viewprevnext' )->rawParams( $prev, $next, $nums )->escaped();
+	}
 }

--- a/www/extensions/Realnames/CHANGELOG
+++ b/www/extensions/Realnames/CHANGELOG
@@ -1,0 +1,59 @@
+This is the changelog for the Realnames extension.
+This extension is pay-what-you want, please consider purchasing it.
+
+http://olivierbeaton.com/mediawiki#realnames
+
+I always love hearing from my users,
+
+email olivier.beaton@gmail.com
+
+any comments, issues, suggestions or complaints.
+
+== 0.3.1 (2011-12-25) ==
+
+bugfix:
+* custom namespace regex (thanks Cweiske)
+* STRICT error with STATIC (thanks Vgold)
+
+notes:
+* removed contrib-agreement, consensus in discussions indicate it's
+ uneeded to remain BSD in shared environment.
+* some progress is being made into core-features for name display, expect
+ some future version to support things like sorting based on realnames (thanks Daniel Friesen)
+* version 0.3 misreported version as 0.2.1, now 0.3.1 (oops, again)
+
+issues:
+* Consensus is that performance could be an issue using current methods. I am currently working
+ on a 2-pass version of the extension to address these issues that will be released as soon as
+ it is ready.
+
+testing:
+* svn trunk 2011-12-26, stable 1.18.0, 1.17.1, 1.16.5, 1.15.5
+
+== 0.3 (2011-11-05) ==
+
+features:
+* you can opt-out of replacements using $wgRealnamesReplacements (thanks Salquint)
+* we now have smarts in the form of not displaying "Marry - Marry" text
+* you can change "smart" features like above using $wgRealnamesSmart
+
+bugfix:
+* version 0.2 misreported version as 0.1.1, now 0.3
+* now tied into main debugging framework
+* a missing return statement was causing titles in append style to get garbled
+
+notes:
+* switched to a more permissive and correct bsd-2-clause license agreement for commits
+* added more metadata files
+
+issues:
+* I continue to be concerned with performance on large recentchanges/history since my initial
+ post about it on 2011-09-19. After receiving a few code reviews recently (finally!) the main
+ feedback has been that there may indeed be scalability problems with using newFromName. In my
+ original post (see extension talk page) I proposed two solutions, but haven't heard from anyone
+ experiencing problems yet. I think I may implement a two-pass as described in the next feature
+ version, however it will make the code significantly more complex. I'll hold off on extending
+ those two specific pages until it's confirmed a two-pass isn't enough.
+
+testing:
+* svn trunk 2011-11-05, 1.18.0beta1, 1.17.0, 1.16.5, 1.15.5

--- a/www/extensions/Realnames/CREDITS
+++ b/www/extensions/Realnames/CREDITS
@@ -1,0 +1,6 @@
+(Cweiske)
+(Nilsy)
+(Salquint)
+(Vgold)
+Daniel Friesen
+Olivier Beaton

--- a/www/extensions/Realnames/HISTORY
+++ b/www/extensions/Realnames/HISTORY
@@ -1,0 +1,58 @@
+This is the historical changelog for the Realnames extension.
+This extension is pay-what-you want, please consider purchasing it.
+
+  http://olivierbeaton.com/mediawiki#realnames
+
+I always love hearing from my users,
+
+  email olivier.beaton@gmail.com
+
+any comments, issues, suggestions or complaints.
+
+== 0.2 (2011-09-22) ==
+
+features:
+* replaces username in personnal url bar (where you click login top right vector)
+* allows custom namespace detection $wgRealnamesNamespaces
+* adds support for Extension:Configure (undoc at release)
+
+bugfix:
+* i18n links User: namespaces (thanks Nilsy)
+* support for upcoming 1.18 gendered namespaces
+* title handling for pre 1.16 wiki's
+* custom namespace names
+
+testing:
+* trunk 2011-09-22 stable 1.17.0, 1.16.0, 1.15.5
+
+== 0.1.1 (2011-09-17) ==
+
+bugfix:
+* eliminated use of create_function due speed implications (thanks Dantman)
+* changed user caching to realname cache for a smaller memory footprint (thanks Dantman)
+* moved debug handling into class and uses $wgRequest, can expand later for 1.18+ (thanks Dantman)
+* license change to BSD, cc is not recommended for software (says them) (thanks Dantman)
+* fixed author link (backported to 0.1, thanks Dantman)
+
+issues:
+* It may be that this extension is slow on RecentChanges and History pages. If so,
+  I have a solution, but I'd rather not introduce more code if I don't have to.
+  If you experience noticable slowdowns on these pages please let me know at
+  olivier dot beaton at gmail dot com
+
+== 0.1 (2011-09-17) ==
+
+initial tested pages:
+* Special:ListUsers
+* old and new Special:RecentChanges
+* Special:Search of the User: space
+* History of page
+* Revisions list of page
+* Revision view of page
+* Revision Compare
+* Page header + html title (limited)
+* Should integrate into any page where user links are found
+
+issues:
+*Always destructive of User: text, new config in future release?
+*improve bare detection on users with spaces or underscores in names (article titles and html title)

--- a/www/extensions/Realnames/LICENSE
+++ b/www/extensions/Realnames/LICENSE
@@ -1,0 +1,21 @@
+Copyright 2011 Olivier Finlay Beaton. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY Olivier Finlay Beaton ''AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Olivier Finlay Beaton OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/www/extensions/Realnames/README
+++ b/www/extensions/Realnames/README
@@ -1,0 +1,12 @@
+Detailed information at: http://www.mediawiki.org/wiki/Extension:Realnames
+
+== Installation ==
+
+To install this extension, add the following to LocalSettings.php:
+require_once("$IP/extensions/Realnames/Realnames.php");
+#add configuration parameters here
+
+== Support ==
+
+It's hoped that you will enjoy the extension, and if you do, consider purchasing it as a pay-what-you-want scheme on the author's website ( http://olivierbeaton.com/mediawiki#realnames ).
+If you find a bug or wish to make a feature request, please contact the author by email olivier.beaton@gmail.com. The talk page is also monitored. The author is often in the #mediawiki irc channel under the nick Finlay.

--- a/www/extensions/Realnames/Realnames.body.php
+++ b/www/extensions/Realnames/Realnames.body.php
@@ -1,0 +1,409 @@
+<?php
+
+/*
+Copyright 2011 Olivier Finlay Beaton. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY Olivier Finlay Beaton ''AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Olivier Finlay Beaton OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * @file
+ * @ingroup Extensions
+ * @authors Olivier Finlay Beaton (olivierbeaton.com)
+ * @copyright BSD-2-Clause http://www.opensource.org/licenses/BSD-2-Clause
+ * @since 2011-09-15, 0.1
+ * @note requires MediaWiki 1.7.0
+ * @note coding convention followed: http://www.mediawiki.org/wiki/Manual:Coding_conventions
+ */
+
+if ( !defined( 'MEDIAWIKI' ) ) {
+        die( 'This file is a MediaWiki extension, it is not a valid entry point' );
+}
+
+/**
+ * @ingroup Extensions
+ * @since 2011-09-15, 0.1
+ * @note requires MediaWiki 1.7.0
+ */
+class ExtRealnames {
+  /**
+   * A cache of realnames for given users
+   * @since 2011-09-16, 0.1
+   */
+  // this used to be a cache of User objects as $users
+  protected static $realnames = array();
+
+  /**
+   * namespace regex option string
+   * @since 2011-09-16, 0.2
+   */
+  protected static $namespacePrefixes = false;
+
+  /**
+   * checks a data set to see if we should proceed with the replacement.
+   * @param[in] $matches \array keyed with regex matches
+   * @return \string text to replace the match with
+   * @since 2011-09-16, 0.1
+   * @see lookForBare() for regex
+   */
+  protected static function checkBare($matches) {
+    // matches come from static::lookForBare()'s regular experession
+    $m = array(
+      'all' => $matches[0],
+      'username' => $matches[1],
+    );
+
+    wfDebugLog('realnames', __METHOD__.': '.print_r($m,true));
+
+    // we do not currently do any checks on Bare replacements, a User: find is
+    // always valid but we could add one in the future, and the debug
+    // information is still conveniant and keeps things consistent with checkLink
+
+    return static::replace($m);
+  } // function
+
+
+  /**
+   * checks a data set to see if we should proceed with the replacement.
+   * @param[in] $matches \array keyed with regex matches
+   * @return \string text to replace the match with
+   * @since 2011-09-16, 0.1
+   * @see lookForBare() for regex
+   */
+  protected static function checkLink($matches) {
+    // matches come from static::lookForLinks()'s regular experession
+    $m = array(
+      'all' => $matches[0],
+      'linkstart' => $matches[1],
+      'linkuser' => $matches[2],
+      'username' => $matches[3],
+      'linkend' => $matches[4],
+    );
+
+    wfDebugLog('realnames', __METHOD__.': '.print_r($m,true));
+
+    // some links point to user pages but do not display the username, we can safely ignore those
+    // we need to urldecode the link for accents and special characters,
+    // and ensure our username has underscores instead of spaces to match our link
+    // before being able to do the comparison.
+    if (urldecode($m['linkuser']) != str_replace(' ','_',$m['username'])) {
+      return $m['all'];
+    }
+
+    return static::replace($m);
+  } // function
+
+  /**
+   * formats the final string in the configured style to display the real name.
+   * @param[in] $m \array keyed with strings called
+   *    \li<em>linkstart</em>
+   *    \li<em>username</em>
+   *    \li<em>realname</em>
+   *    \li<em>linkend</em>
+   * @return \string formatted text to replace the match with
+   * @since 2011-09-16, 0.1
+   * @see $wgRealnamesLinkStyle
+   * @see $wgRealnamesBareStyle
+   * @see $wgRealnamesStyles
+   * @see $wgRealnamesBlank
+   */
+  protected static function display($m) {
+    global $wgRealnamesLinkStyle, $wgRealnamesBareStyle,
+      $wgRealnamesStyles, $wgRealnamesBlank, $wgRealnamesSmart;
+
+    // what kind of formatting will we do?
+    $style = $wgRealnamesLinkStyle;
+    if (empty($m['linkstart'])) {
+      if ($wgRealnamesBareStyle !== false) {
+        $style = $wgRealnamesBareStyle;
+      }
+      $m['linkstart'] = '';
+      $m['linkend'] = '';
+    }
+
+    if (empty($style)) {
+      // error
+      wfDebugLog('realnames', __METHOD__.': error, blank style configuration');
+      return $m['all'];
+    }
+
+    // get the formatting code
+    $format = $wgRealnamesStyles[$style];
+
+    if (empty($style)) {
+      // error
+      wfDebugLog('realnames', __METHOD__.': error, blank format configuration');
+      return $m['all'];
+    }
+
+    // we have a blank username, and the admin doesn't want to see them,
+    // or his chosen format will not display a username at all
+    if (empty($m['realname']) && (
+      !$wgRealnamesBlank || strpos($format,'$2') === false
+      )) {
+      // swap in the username where they expected the realname
+      $format = str_replace('$3','$2',$format);
+    }
+
+    if ($wgRealnamesSmart !== FALSE
+        && $wgRealnamesSmart['same'] === TRUE
+        && $m['username'] === $m['realname']
+        && strpos($format, '$2') !== FALSE
+        && strpos($format, '$3') !== FALSE
+      ) {
+      // we only do this if both username and realname will be displayed iin
+      // the user's format
+
+      wfDebugLog('realnames', __METHOD__.': smart dupe detected');
+
+      // we're going to display: John - John
+      // this is silly. The smart thing to do
+      // is infact nothing (in the name)
+      $format = $wgRealnamesStyles['standard'];
+
+    }
+
+    // plug in our values to the format desired
+    $text = wfMsgReplaceArgs($format, array( // redo to ensure order
+      $m['linkstart'],
+      str_replace('_', ' ',$m['username']),
+      str_replace('_', ' ',$m['realname']),
+      $m['linkend']
+      ));
+
+    wfDebugLog('realnames', __METHOD__.': replacing with '.print_r($text,true));
+
+    return $text;
+  } // function
+
+  /**
+   * gather list of namespace prefixes in the wiki's language.
+   * this is a regex string.
+   * @return \string regex namespace options
+   * @since 2011-09-22, 0.2
+   */
+  public static function getNamespacePrefixes() {
+    global $wgRealnamesNamespaces, $wgContLang, $wgNamespaceAliases;
+
+    // if we already figured it all out, just use that again
+    if (static::$namespacePrefixes !== false) {
+      return static::$namespacePrefixes;
+    }
+
+    // always catch this one
+    $namespaces = array('User:', 'User talk:');
+
+    // add in user specified ones
+    $namespaces = array_merge($namespaces, array_values($wgRealnamesNamespaces));
+
+    // try to figure out the wiki language
+    //! get language from the context somehow? (2011-09-26, ofb)
+    $lang = $wgContLang;
+
+    // user namespace's primary name in the wiki lang
+    $namespaces[] = urlencode($lang->getNsText ( NS_USER )) . ':';
+    $namespaces[] = urlencode($lang->getNsText ( NS_USER_TALK )) . ':';
+
+    // namespace aliases and gendered namespaces (1.18+) in the wiki's lang
+    // fallback for pre 1.16
+    $nss = method_exists($lang, 'getNamespaceAliases') ? $lang->getNamespaceAliases() : $wgNamespaceAliases;
+    foreach ($nss as $name=>$space) {
+      if (in_array($space, array(NS_USER,NS_USER_TALK))) {
+        $namespaces[] = urlencode($name) . ':';
+      }
+    }
+
+    // clean up
+    $namespaces = array_unique($namespaces);
+
+    static::$namespacePrefixes = '(?:'.implode('|',$namespaces).')';
+
+    wfDebugLog('realnames', __METHOD__.': namespace prefixes: '.static::$namespacePrefixes);
+
+    // how did I forget this line before?
+    return static::$namespacePrefixes;
+  } // function
+
+  /**
+   * change all usernames to realnames
+   * @param[inout] &$out OutputPage The OutputPage object.
+   * @param[inout] &$sk Skin object that will be used to generate the page, added in 1.13.
+   * @return \bool true, continue hook processing
+   * @since 2011-09-16, 0.1
+   * @see hook documentation http://www.mediawiki.org/wiki/Manual:Hooks/BeforePageDisplay
+   * @note requires MediaWiki 1.7.0
+   */
+  public static function hookBeforePageDisplay(&$out, &$sk = false) {
+    global $wgTitle, $wgRealnamesReplacements;
+
+    // pre 1.16 no getTitle()
+    $title = method_exists($out,'getTitle') ? $out->getTitle() : $wgTitle;
+
+    if ($wgRealnamesReplacements['title'] === TRUE) {
+      // article title
+      wfDebugLog('realnames', __METHOD__.": searching article title...");
+
+      // special user page handling
+      if (in_array($title->getNamespace(), array(NS_USER, NS_USER_TALK))) { // User:
+        // swap out the specific username from title
+        // this overcomes the problem lookForBare has with spaces and underscores in names
+        while($title->isSubpage()) {
+          $title = $title->getBaseTitle();
+        }
+        $out->setPagetitle(static::lookForBare($out->getPageTitle(),'/'.static::getNamespacePrefixes().'?\s*('.preg_quote ( $title->getText() , '/' ).')/'));
+      }
+
+      // this should also affect the html head title
+      $out->setPageTitle(static::lookForBare($out->getPageTitle()));
+    } // opt-out
+
+    if ($wgRealnamesReplacements['subtitle'] === TRUE) {
+      // subtitle (say, on revision pages)
+      wfDebugLog('realnames', __METHOD__.": searching article subtitle...");
+      $out->setSubtitle(static::lookForLinks($out->getSubtitle()));
+    } // opt-out
+
+    if ($wgRealnamesReplacements['body'] === TRUE) {
+      // article html text
+      wfDebugLog('realnames', __METHOD__.": searching article body...");
+      $out->mBodytext = static::lookForLinks($out->getHTML());
+    } // opt-out
+
+    return true;
+  } // function
+
+  /**
+   * change all usernames to realnames in url bar
+   * @param[inout] &$personal_urls \array the array of URLs set up so far
+   * @param[inout] &$title \obj the Title object of the current article
+   * @return \bool true, continue hook processing
+   * @since 2011-09-22, 0.2
+   * @see hook documentation http://www.mediawiki.org/wiki/Manual:Hooks/PersonalUrls
+   * @note requires MediaWiki 1.7.0
+   */
+  public static function hookPersonalUrls(&$personal_urls, &$title) {
+    global $wgUser, $wgRealnamesReplacements;
+
+    if ($wgRealnamesReplacements['personnal'] === TRUE) {
+      wfDebugLog('realnames', __METHOD__.": searching personnal urls...");
+
+      // replace the name of the logged in user
+      if (isset($personal_urls['userpage']) && isset($personal_urls['userpage']['text'])) {
+        // fake the match, we know it's there
+        $m = array(
+          'all' => $personal_urls['userpage']['text'],
+          'username' => $personal_urls['userpage']['text'],
+          'realname' => $wgUser->getRealname(),
+        );
+        $personal_urls['userpage']['text'] = static::replace($m);
+      }
+    } // opt out
+
+    return true;
+  } // function
+
+  /**
+   * scan and replace plain usernames of the form User:username into real names.
+   * @param[in] \string text to scan
+   * @param[in] \string pattern to match, \bool false for default
+   * @return \string with realnames replaced in
+   * @since 2011-09-16, 0.1
+   * @bug we have problems with users with underscores (they become spaces) or spaces,
+   *    we tend to just strip the User: and leave the username, but we only modify the
+   *    first word so some weird style might screw it up (2011-09-17, ofb)
+   */
+  protected static function lookForBare($text,$pattern=false) {
+    if (empty($pattern)) {
+      // considered doing [^<]+ here to catch names with spaces or underscores,
+      // which works for most titles but is not universal
+      $pattern = '/'.static::getNamespacePrefixes().'([^ \t]+)(:\/.+)?/';
+    }
+    wfDebugLog('realnames', __METHOD__.": pattern: ".$pattern);
+    return preg_replace_callback(
+      $pattern,
+      array( __CLASS__, 'checkBare' ), // create_function is slow
+      $text
+      );
+  } // function
+
+  /**
+   * scan and replace username links into realname links
+   * @param[in] \string text to scan
+   * @param[in] \string pattern to match, \bool false for default
+   * @return \string with realnames replaced in
+   * @since 2011-09-16, 0.1
+   */
+  protected static function lookForLinks($text,$pattern=false) {
+    if (empty($pattern)) {
+      $pattern = '/(<a\b[^">]+href="[^">]+'.static::getNamespacePrefixes().'([^"\\?&>]+)[^>]+>)'.static::getNamespacePrefixes().'?(?:\s*\<bdi\>)?([^><]+)(?:\<\/bdi\>)?(<\/a>)/';
+    }
+    $newText = preg_replace_callback(
+      $pattern,
+      array( __CLASS__, 'checkLink' ), // create_function is slow
+      $text
+      );
+    if($newText == null)
+      return $text;
+    return $newText;
+  } // function
+
+  /**
+   * obtains user information based on a match for future replacement
+   * @param[in] $m \array keyed with strings called
+   *    \li<em>linkstart</em> (optional)
+   *    \li<em>username</em>
+   *    \li<em>realname</em> (optional)
+   *    \li<em>linkend</em> (optional)
+   * @return \string formatted text to replace the match with
+   * @since 2011-09-16, 0.1
+   */
+  protected static function replace($m) {
+    wfDebugLog('realnames', __METHOD__.": matched");
+
+    if (!isset(static::$realnames[$m['username']])) {
+      // we don't have it cached
+      $realname = null;
+
+      if (isset($m['realname'])) {
+        // we got it elsewhere
+        $realname = $m['realname'];
+      } else {
+        // time to do a lookup
+        $user = User::newFromName( $m['username'] );
+
+        if (!is_object($user)) {
+          wfDebugLog('realnames', __METHOD__.": skipped, invalid user: ".$m['username']);
+          return $m['all'];
+        }
+
+        $realname = $user->getRealname();
+      }
+
+      static::$realnames[$m['username']] = htmlspecialchars( trim( $realname ));
+    }
+
+    // this may be blank
+    $m['realname'] = static::$realnames[$m['username']];
+
+    return static::display($m);
+  } // function
+
+} // class

--- a/www/extensions/Realnames/Realnames.php
+++ b/www/extensions/Realnames/Realnames.php
@@ -1,0 +1,179 @@
+<?php 
+
+/*
+Copyright 2011 Olivier Finlay Beaton. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY Olivier Finlay Beaton ''AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Olivier Finlay Beaton OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * Extension to display a user's real name wherever and whenever possible.
+ * @file
+ * @ingroup Extensions
+ * @version 0.3.1
+ * @authors Olivier Finlay Beaton (olivierbeaton.com)  
+ * @copyright BSD-2-Clause http://www.opensource.org/licenses/BSD-2-Clause  
+ * @note this extension is pay-what-you-want, please consider a purchase at http://olivierbeaton.com/
+ * @since 2011-09-15, 0.1
+ * @note requires MediaWiki 1.7.0   
+ * @note coding convention followed: http://www.mediawiki.org/wiki/Manual:Coding_conventions
+ */
+ 
+if ( !defined( 'MEDIAWIKI' ) ) {
+        die( 'This file is a MediaWiki extension, it is not a valid entry point' );
+}
+
+/* (not our var to doc)
+ * extension credits
+ * @since 2011-09-16, 0.1
+ */
+$wgExtensionCredits['parserhook'][] = array(
+  'name' => 'Realnames',
+  'author' =>array('[http://olivierbeaton.com/ Olivier Finlay Beaton]'), 
+  'version' => '0.3.1',
+  'url' => 'http://www.mediawiki.org/wiki/Extension:Realnames', 
+  'description' => 'Displays a user\'s real name everywhere',
+ );
+
+/**
+ * The format to apply to a user link.
+ * @since 2011-09-15, 0.1
+ * @see $wgRealnamesFormats 
+ */ 
+$wgRealnamesLinkStyle = 'replace';
+
+/**
+ * The format to apply to a user's name in text. 
+ * This typically only replaces User: text in titles
+ * @since 2011-09-16, 0.1
+ */  
+$wgRealnamesBareStyle = false;
+
+/**
+ * Do you want to show blank real names?
+ * If this is false, then it will fall back on a 'replace' username style.
+ * If true, then in a style like 'append' ( Joe [Joe Cardigan] )you will see: Joe []  
+ * @note User:Joe text will still become Joe.
+ * @since 2011-09-15, 0.1
+ */    
+$wgRealnamesBlank = false;
+
+/**
+ * Ability to turn on/off replacement in each area.
+ * This runs a bit counter to the idea of the extension, to simply replace all
+ * names on the page, however baring better names handling sometimes turning off
+ * say (titles) is the only way to go and I don't want people to have to fork/patch
+ * the code to do so.
+ * @attention use of opt-outs here is discouraged.
+ * @since 2011-11-05, 0.1
+ */
+$wgRealnamesReplacements = array(
+    'title' => TRUE,
+    'subtitle' => TRUE,
+    'personnal' => TRUE,
+    'body' => TRUE,
+  );
+
+/**
+ * Possible styles to pick from, you can define new ones as well.
+ * The following variables are set:<br> 
+ * \li $1  link start
+ * \li $2  username
+ * \li $3  real name
+ * \li $4  link end
+ * @note If you want to add markup, you should set $wgRealnamesBareStyle to a style without html (it's doesnt work in bare)
+ * @since 2011-09-15, 0.1  
+ */
+$wgRealnamesStyles = array( 
+    'standard' => '$1$2$4',
+    'append' => '$1$2$4 [$3]',
+    'replace' => '$1$3$4',
+    'reverse' => '$1$3$4 [$2]',
+    'dash' => '$1$2$4 &ndash; $3',
+    'femiwiki' => '$3 [$1$2$4]',
+  ); 
+  
+/**
+ * Allows you to turn off smart behaviour.
+ * Set the var to FALSE to disable all,
+ * or turn off individual features.
+ */
+$wgRealnamesSmart = array(
+    'same' => TRUE,
+  );
+  
+/**
+ * extra namespaces names to look for.
+ * @note do not include the ':'
+ * @note this is a regexp so escaping may be required. 
+ * @since 2011-09-22, 0.2
+ */ 
+$wgRealnamesNamespaces = array();
+ 
+if (isset($wgConfigureAdditionalExtensions) && is_array($wgConfigureAdditionalExtensions)) {
+
+  /* (not our var to doc)
+   * attempt to tell Extension:Configure how to web configure our extension
+   * @since 2011-09-22, 0.2 
+   */ 
+  $wgConfigureAdditionalExtensions[] = array(
+      'name' => 'Realnames',
+      'settings' => array(
+          'wgRealnamesLinkStyle' => 'text',
+          'wgRealnamesBareStyle' => 'bool',
+          'wgRealnamesBlank' => 'bool',
+          'wgRealnamesStyles' => 'array',   
+          'wgRealnamesSmart' => 'array',
+          'wgRealnamesReplacements' => 'array',
+          'wgRealnamesNamespaces' => 'array',     
+        ),
+      'array' => array(
+          'wgRealnamesStyles' => 'assoc',
+          'wgRealnamesSmart' => 'assoc',
+          'wgRealnamesReplacements' => 'assoc',
+          'wgRealnamesNamespaces' => 'simple',
+        ),
+      'schema' => false,
+      'url' => 'http://www.mediawiki.org/wiki/Extension:Realnames',
+    );
+   
+} // $wgConfigureAdditionalExtensions exists
+   
+ 
+/* (not our var to doc)
+ * Our extension class, it will load the first time the core tries to access it
+ * @since 2011-09-16, 0.1  
+ */ 
+$wgAutoloadClasses['ExtRealnames'] = dirname(__FILE__) . '/Realnames.body.php';
+
+/* (not our var to doc)
+ * This hook is called before the article is displayed.  
+ * @since 2011-09-16, 0.1  
+ * @see $wgAutoloadClasses for how the class gets defined.  
+ */
+$wgHooks['BeforePageDisplay'][] = 'ExtRealnames::hookBeforePageDisplay';
+
+/* (not our var to doc)
+ * This hook is called before the user links are displayed.  
+ * @since 2011-09-22, 0.2  
+ * @see $wgAutoloadClasses for how the class gets defined.  
+ */
+$wgHooks['PersonalUrls'][] = 'ExtRealnames::hookPersonalUrls';

--- a/www/fw-resources/favicons/manifest.json
+++ b/www/fw-resources/favicons/manifest.json
@@ -1,5 +1,5 @@
 {
- "name": "App",
+ "name": "페미위키",
  "icons": [
   {
    "src": "\/android-icon-36x36.png",
@@ -37,5 +37,8 @@
    "type": "image\/png",
    "density": "4.0"
   }
- ]
+ ],
+ "display": "standalone",
+ "theme_color": "#aca6e4",
+ "background_color": "#aca6e4"
 }

--- a/www/provision.sh
+++ b/www/provision.sh
@@ -158,6 +158,7 @@ then
     sudo cp /vagrant/www/google6a8c7f190836bc0d.html /var/www/femiwiki.com/
     sudo cp /vagrant/www/naver09b95fd90c3231a5a37f42d39222c217.html /var/www/femiwiki.com/
     sudo cp /vagrant/www/favicon.ico /var/www/femiwiki.com/
+    sudo cp -r /vagrant/www/extensions/Realnames /var/www/femiwiki.com/extensions/
     sudo cp -r /vagrant/www/extensions/FacetedCategory /var/www/femiwiki.com/extensions/
     sudo cp -r /vagrant/www/extensions/ExtendedSpecialPagesForFemiwiki /var/www/femiwiki.com/extensions/
     sudo cp -r /vagrant/www/extensions/CategoryIntersectionSearch /var/www/femiwiki.com/extensions/
@@ -167,6 +168,7 @@ else
     sudo ln -sf /vagrant/www/google6a8c7f190836bc0d.html /var/www/femiwiki.com/google6a8c7f190836bc0d.html
     sudo ln -sf /vagrant/www/naver09b95fd90c3231a5a37f42d39222c217.html /var/www/femiwiki.com/naver09b95fd90c3231a5a37f42d39222c217.html
     sudo ln -sf /vagrant/www/favicon.ico /var/www/femiwiki.com/favicon.ico
+    sudo ln -sf /vagrant/www/extensions/Realnames /var/www/femiwiki.com/extensions/Realnames
     sudo ln -sf /vagrant/www/extensions/FacetedCategory /var/www/femiwiki.com/extensions/FacetedCategory
     sudo ln -sf /vagrant/www/extensions/ExtendedSpecialPagesForFemiwiki /var/www/femiwiki.com/extensions/ExtendedSpecialPagesForFemiwiki
     sudo ln -sf /vagrant/www/extensions/CategoryIntersectionSearch /var/www/femiwiki.com/extensions/CategoryIntersectionSearch

--- a/www/provision.sh
+++ b/www/provision.sh
@@ -83,6 +83,11 @@ if [ ! -f /opt/femiwiki-provisioned ]; then
     sudo tar -xzf CodeEditor-REL1_27-5e8053d.tar.gz -C /var/www/femiwiki.com/extensions
     rm CodeEditor-REL1_27-5e8053d.tar.gz
 
+    ## AbuseFilter
+    wget -nv https://extdist.wmflabs.org/dist/extensions/AbuseFilter-REL1_27-2072d2f.tar.gz
+    sudo tar -xzf AbuseFilter-REL1_27-2072d2f.tar.gz -C /var/www/femiwiki.com/extensions
+    rm AbuseFilter-REL1_27-2072d2f.tar.gz
+
     ## UserMerge
     wget -nv https://extdist.wmflabs.org/dist/extensions/UserMerge-REL1_27-31ea86d.tar.gz
     sudo tar -xzf UserMerge-REL1_27-31ea86d.tar.gz -C /var/www/femiwiki.com/extensions

--- a/www/skins/Femiwiki/FemiwikiTemplate.php
+++ b/www/skins/Femiwiki/FemiwikiTemplate.php
@@ -7,6 +7,7 @@
  */
 class FemiwikiTemplate extends BaseTemplate
 {
+    protected static $googleApiKey = 'AIzaSyC3vDxqg6zA-f8qU--V488nngsBYnZZgPc';
     /**
      * Outputs the entire contents of the page
      */
@@ -139,13 +140,12 @@ class FemiwikiTemplate extends BaseTemplate
                         'a',
                         array(
                             'id' => 'lastmod',
+                            'title' => '문서의 과거 판 [alt-shift-h]',
                             'href' => '/index.php?title='.$this->getSkin()->getRelevantTitle().'&action=history'
                         ),
                         $this->get('lastmod')
                         );
 
-
-                unset( $this->data['content_navigation']['views']['history'] );
                 echo $this->getPortlet(array(
                     'id' => 'p-views',
                     'headerMessage' => 'views',
@@ -336,13 +336,13 @@ class FemiwikiTemplate extends BaseTemplate
             $nav['views'][$mode]['class'] = rtrim( 'icon ' . $nav['views'][$mode]['class'], ' ' );
             $nav['views'][$mode]['primary'] = true;
             unset( $this->data['content_navigation']['actions'][$mode] );
+            $item = $nav['actions'][$mode];
+            $attrs = [];
+            $attrs['class'] = 'mw-portlet';
+            $attrs['id'] = 'ca-watch';
+            
+            return Html::rawElement( 'span', $attrs, $this->makeLink( $mode, $item ) );
         }
-        $item = $nav['actions'][$mode];
-        if($item === null) return;
-        $attrs = [];
-        $attrs['class'] = 'mw-portlet';
-        $attrs['id'] = 'ca-watch';
-        return Html::rawElement( 'span', $attrs, $this->makeLink( $mode, $item, $options ) );
     }
 
     /**
@@ -373,7 +373,7 @@ class FemiwikiTemplate extends BaseTemplate
                 'id'=>'searchClearButton',
                 'type' => 'button'
             ],
-            ×
+            '×'
         );
         $html .= $this->makeSearchButton('go', array('id' => 'searchGoButton', 'class' => 'searchButton'));
         $html .= Html::closeElement('form');
@@ -455,17 +455,46 @@ class FemiwikiTemplate extends BaseTemplate
 
     function getShareToolbox() {
         $toolbox = [];
+        global $wgServer; //$wgServer = 'https://femiwiki.com';
+        $canonicalLink = $wgServer.'/w/'.str_replace('%2F','/',urlencode($this->get('titleprefixeddbkey'))).'?utm_campaign=share';
+
+        $toolbox['copy'] = [];
+        $toolbox['copy']['id'] = 'share-copy';
+        $toolbox['copy']['href'] = self::shortenURL($canonicalLink);
+        $toolbox['copy']['text'] = 'URL 복사';
+
+        $toolbox['facebook'] = [];
+        $toolbox['facebook']['id'] = 'share-facebook';
+        $toolbox['facebook']['target'] = '_blank';
+        $link = $this->shortenURL($canonicalLink.'&utm_source=facebook&utm_medium=post');
+        $toolbox['facebook']['href'] = $link;
+        $toolbox['facebook']['text'] = '페이스북';
+
 
         $toolbox['twitter'] = [];
-        $toolbox['twitter']['id'] = 'twitter';
+        $toolbox['twitter']['id'] = 'share-twitter';
         $toolbox['twitter']['target'] = '_blank';
-        global $wgServer;
-        $link = $wgServer.'/index.php?curid='.$this->get('articleid').'?utm_source=twitter&utm_medium=tweet';
+        $link = $this->shortenURL($canonicalLink.'&utm_source=twitter&utm_medium=tweet');
         $tweet = $this->get('title').' '.$link.' #'.$this->get('sitename');
         $toolbox['twitter']['href'] = 'https://twitter.com/intent/tweet?text='.urlencode($tweet);
         $toolbox['twitter']['text'] = '트위터';
 
         return $toolbox;
+    }
+
+    static function shortenURL($longURL){
+        $ch = curl_init();
+
+        curl_setopt($ch, CURLOPT_URL,'https://www.googleapis.com/urlshortener/v1/url'.'?key='.self::$googleApiKey);
+        curl_setopt($ch, CURLOPT_POST,1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS,json_encode(array("longUrl"=>$longURL)));
+        curl_setopt($ch, CURLOPT_HTTPHEADER,array("Content-Type: application/json"));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        $result = curl_exec($ch);
+        curl_close($ch);
+        if($result !== null && !isset(json_decode($result)->{'id'})) return $longURL;
+        return json_decode($result)->{'id'};
     }
 
     /**

--- a/www/skins/Femiwiki/FemiwikiTemplate.php
+++ b/www/skins/Femiwiki/FemiwikiTemplate.php
@@ -44,7 +44,7 @@ class FemiwikiTemplate extends BaseTemplate
 
                     <ul id="site-navigation">
                         <li class="changes"><a href="/w/Special:RecentChanges" title="바뀐글"><span class="text">바뀐글</span></a></li>
-                        <li class="random"><a href="/w/특:임의문서/일반" title="임의글"><span class="text">임의글</span></a></li>
+                        <li class="random"><a href="/w/Special:RandomPage" title="임의글"><span class="text">임의글</span></a></li>
                     </ul>
 
                     <?php

--- a/www/skins/Femiwiki/resources/main.js
+++ b/www/skins/Femiwiki/resources/main.js
@@ -20,38 +20,39 @@ var _FW = {
   BBS_NS: [3902, 3904]
 };
 
-
 $(function () {
+  // Let menu fill parent
   function menuResize(divId){
     var containerWidth = parseFloat($('#'+divId).css('width'))
       -parseFloat($('#'+divId).css('padding-left'))
       -parseFloat($('#'+divId).css('padding-right')),
-      itemPadding
-        =parseFloat($('#'+divId+' > div').css('padding-left'))
+      itemPadding =
+        parseFloat($('#'+divId+' > div').css('padding-left'))
         +parseFloat($('#'+divId+' > div').css('padding-right')),
-      itemMargin
-        =parseFloat($('#'+divId+' > div').css('margin-left'))
+      itemMargin =
+        parseFloat($('#'+divId+' > div').css('margin-left'))
         +parseFloat($('#'+divId+' > div').css('margin-right')),
       itemActualMinWidth = 
         parseFloat($('#'+divId+' > div').css('min-width'))
         +itemPadding+itemMargin,
-      itemLength = $('#'+divId+' > div').filter(function() {
-          return $(this).css('display') !== 'none';
-      }).length,
-      horizontalCapacity = Math.min(Math.floor(containerWidth / itemActualMinWidth),itemLength);
+      itemLength = 
+          $('#'+divId+' > div').filter(function() {
+            return $(this).css('display') !== 'none';
+          }).length,
+      horizontalCapacity = 
+        Math.min(
+          Math.floor(containerWidth / itemActualMinWidth),
+          itemLength
+        );
 
-    $('#'+divId+' > div').css("width",Math.floor(containerWidth/horizontalCapacity-itemPadding-itemMargin));
+    $('#'+divId+' > div').css("width",Math.floor(
+      containerWidth/horizontalCapacity
+      -itemPadding
+      -itemMargin
+    ));
   }
 
-  var searchInput = $('#searchInput'),
-   searchClearButton = $('#searchClearButton');
-  searchInput.on("input", function(){
-    searchClearButton.toggle(!!this.value);
-  });
-  searchClearButton.click(function () {
-    searchInput.val("").trigger('input').focus();
-  });
-
+  // Menu toggle
   $('#fw-menu-toggle').click(function () {
     $('#fw-menu').toggle();
     menuResize('fw-menu');
@@ -67,6 +68,16 @@ $(function () {
     menuResize('p-actions-and-toolbox')
   });
 
+  // Search claer button
+  var searchInput = $('#searchInput'),
+   searchClearButton = $('#searchClearButton');
+  searchInput.on("input", function(){
+    searchClearButton.toggle(!!this.value);
+  });
+  searchClearButton.click(function () {
+    searchInput.val("").trigger('input').focus();
+  });
+
   // Notification badge
   var alerts = +$('#pt-notifications-alert').text();
   var messages = +$('#pt-notifications-message').text();
@@ -80,9 +91,34 @@ $(function () {
   $('#pt-notifications-alert a').text('알림: ' + alerts);
   $('#pt-notifications-message a').text('메시지: ' + messages);
 
-  // Move fw-catlinks
-  var $catlinks = $('.fw-catlinks');
-  $('#bodyContent').append($catlinks);
+  // Collapsible category links
+  var catlinksToggle = $('<button></button>');
+  catlinksToggle.text("►");
+  catlinksToggle.addClass('fw-catlinks-toggle');
+
+  var catlinks = $('#mw-normal-catlinks li'),
+    directCatAnchors = $('#fw-catlinks li>a'),
+    directCatTexts = {};
+  for(var i=0,len=directCatAnchors.length;i<len;i++)
+    directCatTexts[directCatAnchors[i].text] = true;
+
+  if(directCatAnchors.length !== catlinks.length) {
+    for(var i=0,len=catlinks.length;i<len;i++)
+      if( !directCatTexts[catlinks[i].innerText] )
+       catlinks[i].className += ' collapsible' ;
+
+    $('#catlinks li.collapsible').fadeOut();
+    var collapsed = true;
+    catlinksToggle.click(function () {
+      $(this).text($(this).text() == "▼" ? "►" : "▼");
+      if(collapsed)
+        $('#catlinks li.collapsible').fadeIn();
+      else
+        $('#catlinks li.collapsible').fadeOut();
+      collapsed = !collapsed;
+    });
+    $('#mw-normal-catlinks').prepend(catlinksToggle);
+  }
 
   // Do not show edit page when user clicks red link
   $('#bodyContent a').each(function() {

--- a/www/skins/Femiwiki/resources/main.js
+++ b/www/skins/Femiwiki/resources/main.js
@@ -137,9 +137,21 @@ $(function () {
     }
   })
 
+  // Set Mathjax linebreaks configuration
   MathJax.Hub.Config({
     CommonHTML: { linebreaks: { automatic: true } },
     "HTML-CSS": { linebreaks: { automatic: true } },
            SVG: { linebreaks: { automatic: true } }
+  });
+  
+  // Center single Mathjax line
+  MathJax.Hub.Queue(function () {
+    $('#content p > span:only-child > span.MathJax,'
+    +'#content p > span.mathjax-wrapper:only-child > div').each(function(){
+      if(!$(this).parent().parent().clone().children().remove().end().text().trim().length) {
+        $(this).parent().css('display','block');
+        $(this).parent().css('text-align','center');
+      }
+    });
   });
 });

--- a/www/skins/Femiwiki/resources/mute.js
+++ b/www/skins/Femiwiki/resources/mute.js
@@ -3,7 +3,7 @@
 
   var $muteLinkEl = $('<li id="footer-places-mute"><a href="#">뮤트</a></li>');
   var $editorEl = $(
-    '<div id="muteEditor" style="display: none;">' +
+    '<div id="muteEditor" class="dialog" style="display: none;">' +
     '<form>' +
     '  <textarea id="muteEditor-text" placeholder="감출 키워드를 한 줄에 하나씩 입력하세요."></textarea>' +
     '  <input type="submit" value="저장">' +

--- a/www/skins/Femiwiki/resources/screen-changes.less
+++ b/www/skins/Femiwiki/resources/screen-changes.less
@@ -195,10 +195,11 @@
       // arrow, "new" flag, timestamp
       .newpage,
       .minoredit,
+      .botedit,
       .unpatrolled {
         position: absolute;
         right: 0;
-        margin-right: 1rem;
+        margin-right: 2rem;
       }
       .unpatrolled {
         margin-right: 0.5rem;
@@ -264,7 +265,7 @@
       }
 
       .mw-collapsible-toggle {
-        float: left;
+        float: right;
         display: block;
         margin-top: 0.3rem;
       }

--- a/www/skins/Femiwiki/resources/screen-common.less
+++ b/www/skins/Femiwiki/resources/screen-common.less
@@ -108,11 +108,6 @@ button {
   cursor: pointer;
 }
 
-#content .mw-ui-button.mw-ui-primary,
-#content .oo-ui-buttonElement-button {
-  color: #FFFFFF;
-}
-
 #p-navigation-and-watch {
   max-width: 50rem;
   padding: 0 1.3rem;
@@ -134,7 +129,7 @@ button {
   #siteNotice {
     font-size: 0.8rem;
     color: #000;
-    margin: 0 0 4rem;
+    margin: 0 0 2.3rem;
     padding: 0rem 0.8rem;
     border: 2px solid #aca8e0;
 
@@ -166,106 +161,9 @@ button {
   }
 }
 
-#content #p-header {
-
-  #p-title-and-tb{
-
-    #p-actions-and-toolbox {
-      display: none;
-      clear:right;
-      text-align: right;
-      overflow:hidden;
-      border-bottom: 1px solid #aca6e4;
-
-      #p-actions, #p-page-tb, #p-share-tb, #p-site-tb {
-        float:right;
-        min-width: 8.8rem;
-        margin: 0.6rem 0.8rem 0.6rem 0;
-        display: inline-block;
-        vertical-align: top;
-        text-align: left;
-        h3 {
-          margin:0;
-          font-weight: normal;
-          font-size: 1rem;
-          border-bottom: 1px solid #b9b5d9;
-          margin-bottom: 0.4rem;
-        }
-
-        ul {
-          padding: 0;
-          margin: 0;
-        }
-
-        li {
-          list-style-type: none;
-          margin: 0;
-        }
-
-        a {
-          display: block;
-        }
-      }
-
-      div + div {
-        margin-right:1em;
-      }
-    }
-
-    h1.firstHeading {
-      font-size: 1.714rem;
-      margin-bottom: 0;
-      display: inline-block;
-      margin-top: 0;
-    }
-    #p-links-toggle {
-      background-color: transparent;
-      color: #252525;
-      float:right;
-      padding: .4rem;
-    }
-  }
-  #lastmod-and-views {
-    font-size:0.75rem;
-    overflow:hidden;
-    clear:both;
-
-    #p-views {
-      h3 {
-        display: none;
-      }
-
-      ul {
-        padding: 0;
-        margin: 0;
-        li {
-          margin: 0;
-          display: block;
-        }
-        li.selected a {
-          font-weight: bold;
-        }
-      }
-
-      li#ca-view.selected {
-        display: none;
-      }
-    }
-
-
-    #p-views {
-      float:right;
-      li{
-        float:left;
-      }
-      li + li {
-        margin-left:1em;
-      }
-    }
-    #lastmod {
-      font-size:0.8rem;
-    }
-  }
+#content .mw-ui-button.mw-ui-primary,
+#content .oo-ui-buttonElement-button {
+  color: #FFFFFF;
 }
 
 // Content
@@ -280,7 +178,6 @@ button {
     float: right;
   }
 
-
   #mw-notification-area {
     width: auto;
     max-width: 16rem;
@@ -293,6 +190,106 @@ button {
     .mw-notification {
       border: solid 1px #b2d236;
       background-color: #dae8b2;
+    }
+  }
+
+  #p-header {
+    #p-title-and-tb{
+      #p-actions-and-toolbox {
+        display: none;
+        clear:right;
+        text-align: right;
+        overflow:hidden;
+        border-bottom: 1px solid #aca6e4;
+
+        #p-actions, #p-page-tb, #p-share-tb, #p-site-tb {
+          float:right;
+          min-width: 8.8rem;
+          margin: 0.6rem 0.8rem 0.6rem 0;
+          display: inline-block;
+          vertical-align: top;
+          text-align: left;
+          h3 {
+            margin:0;
+            font-weight: normal;
+            font-size: 1rem;
+            border-bottom: 1px solid #b9b5d9;
+            margin-bottom: 0.4rem;
+          }
+
+          ul {
+            padding: 0;
+            margin: 0;
+          }
+
+          li {
+            list-style-type: none;
+            margin: 0;
+          }
+
+          a {
+            display: block;
+          }
+        }
+
+        div + div {
+          margin-right:1em;
+        }
+      }
+
+      h1.firstHeading {
+        font-size: 1.714rem;
+        margin-bottom: 0;
+        display: inline-block;
+        margin-top: 0;
+      }
+      #p-links-toggle {
+        background-color: transparent;
+        color: #252525;
+        float:right;
+        padding: .4rem;
+      }
+    }
+    #lastmod-and-views {
+      font-size:0.75rem;
+      overflow:hidden;
+      clear:both;
+
+      #p-views {
+        h3 {
+          display: none;
+        }
+
+        ul {
+          padding: 0;
+          margin: 0;
+          li {
+            margin: 0;
+            display: block;
+          }
+          li.selected a {
+            font-weight: bold;
+          }
+        }
+
+        li#ca-view.selected, li#ca-history {
+          display: none;
+        }
+      }
+
+
+      #p-views {
+        float:right;
+        li{
+          float:left;
+        }
+        li + li {
+          margin-left:1em;
+        }
+      }
+      #lastmod {
+        font-size:0.8rem;
+      }
     }
   }
 
@@ -368,6 +365,7 @@ button {
 
   // Quote
   blockquote {
+    display: inline-block;
     margin: 1.6rem 1rem 1.6rem 1.2rem;
     position: relative;
   }
@@ -384,6 +382,25 @@ button {
     position: absolute;
     left: -1.3rem;
     top: -1rem;
+  }
+  blockquote::after {
+    content: "\201D"; /*Unicode for Right Double Quote*/
+
+    /*Font*/
+    font-family: Georgia, serif;
+    font-size: 2rem;
+    font-weight: bold;
+    color: #999;
+
+    /*Positioning*/
+    position: absolute;
+    right: -1.3rem;
+    bottom: -1rem;
+  }
+
+  // Pre
+  pre {
+    overflow-x:auto;
   }
 
   // Links
@@ -610,12 +627,24 @@ button {
     vertical-align: middle;
   }
 
-  // Hide default category and show femiwiki category instead
-  #catlinks {
+  // CategoryTree
+  .CategoryTreeToggle {
+    float:right;
+    font-size: .7rem;
+    padding: .3rem;
+    color:#797979;
+  }
+  .CategoryTreeEmptyBullet {
     display: none;
   }
+
+  // Hide femiwiki category
   .fw-catlinks {
-    margin: 4rem 0 0;
+    display: none;
+  }
+
+  .catlinks, .fw-catlinks {
+    margin: 2.2rem 0;
     padding: 0;
     border-width: 0;
     background-color: transparent;
@@ -634,12 +663,16 @@ button {
       line-height: inherit;
     }
 
-    li::after {
+    li:not(:first-child):before {
       content: "|";
       margin: 0 0.3rem;
     }
-    li:last-child::after {
-      content: "";
+
+    .fw-catlinks-toggle {
+      float:right;
+      font-size:.7rem;
+      color:#797979;
+      background-color: transparent;
     }
   }
 
@@ -794,6 +827,11 @@ html.ve-active {
     // Remove padding of visual editor
     .ve-ce-documentNode {
       padding: 0;
+    }
+
+    // show femiwiki category
+    .fw-catlinks {
+      display: block;
     }
   }
 
@@ -972,12 +1010,25 @@ html.ve-active {
     }
 
     .nav-bar,
+    #p-navigation-and-watch,
     #mw-footer {
       display: none;
     }
 
     .oo-ui-toolbar-tools {
-      z-index: 1;
+      // z-index: 1;
+    }
+  }
+  html.ve-active, div.flow-board, .oo-ui-window-frame {
+    .oo-ui-popupWidget-popup {
+      min-width: 16rem;
+      min-height: 10rem;
+    }
+    div.oo-ui-menuLayout-menu {
+      width:3rem;
+    }
+    div.oo-ui-menuLayout-content {
+      left:3rem;
     }
   }
 }

--- a/www/skins/Femiwiki/resources/screen-dialog.less
+++ b/www/skins/Femiwiki/resources/screen-dialog.less
@@ -1,4 +1,4 @@
-#muteEditor {
+.dialog {
   * {
     box-sizing: border-box;
   }
@@ -14,15 +14,17 @@
   color: #fff;
   background-color: rgba(0, 0, 0, 0.7);
 
-  textarea {
-    margin: 0.5rem 0 1rem;
-    padding: 0.5rem;
-    height: 10rem;
-  }
-
   p {
     margin-top: 0.8rem;
     font-size: 0.8rem;
     line-height: 1.4;
+  }
+}
+
+.dialog#muteEditor {
+  textarea {
+    margin: 0.5rem 0 1rem;
+    padding: 0.5rem;
+    height: 10rem;
   }
 }

--- a/www/skins/Femiwiki/resources/screen-gnb.less
+++ b/www/skins/Femiwiki/resources/screen-gnb.less
@@ -196,11 +196,11 @@
 
   .mw-portlet,
   .portal {
+    direction: ltr;
     min-width: 8.8rem;
     margin: 0.6rem 0.8rem 0.6rem 0;
     display: inline-block;
     vertical-align: top;
-    text-align: left;
 
     h3 {
       font-weight: normal;

--- a/www/skins/Femiwiki/resources/share.js
+++ b/www/skins/Femiwiki/resources/share.js
@@ -1,0 +1,63 @@
+(function() {
+  const facebookAppId = '1937597133150935';
+
+  var $editorEl = $(
+    '<div id="share" class="dialog" style="display: none;">' +
+    '<p>' +
+    '  아래를 복사하세요.' +
+    '</p>' +
+    '<form>' +
+    '  <textarea readonly id="share-text"></textarea>' +
+    '  <input type="reset" value="닫기">' +
+    '</form>' +
+    '</div>'
+  );
+
+  function _initUI() {
+    $(document.body).append($editorEl);  
+    $('#share-copy').find('a').on('click', function(e) {
+      e.preventDefault();
+
+      $editorEl.show();
+      $('textarea#share-text').html($(this).attr('href')).select().focus(function(){
+        $(this).select();
+      });
+     });
+    $editorEl.find('input[type="reset"]').on('click', function(e) {
+      e.preventDefault();
+      $editorEl.hide();
+    });
+
+    window.fbAsyncInit = function() {
+      FB.init({
+        appId            : facebookAppId,
+        autoLogAppEvents : true,
+        xfbml            : true,
+        version          : 'v2.10'
+      });
+      FB.AppEvents.logPageView();
+    };
+
+    (function(d, s, id){
+       var js, fjs = d.getElementsByTagName(s)[0];
+       if (d.getElementById(id)) {return;}
+       js = d.createElement(s); js.id = id;
+       js.src = "//connect.facebook.net/en_US/sdk.js";
+       fjs.parentNode.insertBefore(js, fjs);
+     }(document, 'script', 'facebook-jssdk'));
+    $('#share-facebook').find('a').on('click', function(e) {
+      e.preventDefault();
+      
+      FB.ui({
+      method: 'share',
+      href: $(this).attr('href'),
+    }, function(response){});
+    });
+  }
+
+  // Init UI
+  $(function() {
+    _initUI();
+  });
+})();
+

--- a/www/skins/Femiwiki/skin.json
+++ b/www/skins/Femiwiki/skin.json
@@ -26,7 +26,7 @@
         "resources/screen-common.less": {
           "media": "screen"
         },
-        "resources/screen-mute.less": {
+        "resources/screen-dialog.less": {
           "media": "screen"
         },
         "resources/screen-table.less": {
@@ -57,6 +57,7 @@
       "scripts": [
         "resources/main.js",
         "resources/mute.js",
+        "resources/share.js",
         "resources/recentchanges.js",
         "resources/bbs.js"
       ]


### PR DESCRIPTION
- 모든 계정명 표시가 닉네임과 계정명 병기로 교체됩니다.
- AbuseFilter 확장기능을 설치합니다.
- 게시판 이름공간들이 콘텐츠 이름공간에서 제외됩니다(일부 특수 문서 작업의 범위에서 제외됩니다)
- 모바일 구글 크롬에서 "홈 화면에 추가"로 추가되는 웹 앱을 전체화면으로 변경하였습니다.
- 분류 트리, 최근 바뀜의 토글 버튼을 오른쪽으로 이동하였습니다.
- 분류 트리의 토글버튼을 기본값 파란색에서 회색으로 변경하였습니다.
- 문서 분류 오른쪽에 토글 버튼을 설치하여 이것을 누르면 전체 분류가 보이게 변경하였습니다.
- - javascript가 작동하지 않을 경우 펼쳐진 상태로 고정되며 토글 버튼도 표시되지 않습니다.
- - 페미위키 스킨이 아닐 경우 이전과 동일하게 두 분류가 모두 보입니다.
- 공유하기에 URL 복사 메뉴를 추가하였습니다.
- blockquote를 inlink-block으로 설정하고 닫는 따옴표를 추가하였습니다.
- 스킨을 수정하면서 Alt+Shift+H 문서 역사 보기 단축키가 삭제된 것을 복구했습니다.
- pre 태그를 이용한 내용이 너무 길 경우 스크롤바를 표시합니다.
- 스킨의 여백을 조정하였습니다.
- 메세지와 알림이 비정상적으로 표시되던 버그를 수정하였습니다.
- 공유하기로 공유되는 URL을 단축하였습니다.
- oo-ui-popupWidget-popup에 min-width와 min-height를 적용하였습니다.(모바일에서 width가 지나치게 작아지는 걸 막기 위해)
- 폭이 적을 때 oo-ui-menuLayout-menu의 width를 줄이도록 설정했습니다.
- Mathjax가 한 줄에 하나 존재할 경우 가운데 정렬을 하도록 하였습니다.
- 공유하기에 페이스북 버튼을 추가하였습니다.