### PR TITLE
Autoconfirmed user group의 시간 설정 및 편집 권한 변경

### DIFF
--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -165,8 +165,18 @@ $wgGroupPermissions['sysop']['deleterevision'] = true;
 ## Prevent anonymous users from edit pages
 $wgGroupPermissions['*']['edit'] = false;
 
-## Allow registered users to edit pages
-$wgGroupPermissions['user']['edit'] = true;
+## Set when users become autoconfirmed users
+$wgAutoConfirmCount = 0;
+$wgAutoConfirmAge = 10800;
+$wgAutopromote = array(
+	"autoconfirmed" => array( "&",
+		array( APCOND_EDITCOUNT, &$wgAutoConfirmCount ),
+		array( APCOND_AGE, &$wgAutoConfirmAge ),
+	),
+);
+## Allow autoconfirmed users to edit pages
+$wgGroupPermissions['user']['edit'] = false;
+$wgGroupPermissions['autoconfirmed']['edit'] = true;
 $wgGroupPermissions['seeder']['edit'] = true;
 $wgGroupPermissions['bureaucrat']['edit'] = true;
 


### PR DESCRIPTION
Autoconfirmed user group 에 들어가려면 위키에 등록하고나서 편집 횟수는 0회 이상이고 3시간이 넘어야 하도록 설정.
일반 사용자 그룹은 편집할 수 없고, autoconfirmed user가 되어야 편집할 수 있도록 편집 권한 조정.