### PR TITLE
 Notification 위젯을 커스텀 위젯으로 대체

### DIFF
--- a/www/skins/Femiwiki/Femiwiki.skin.php
+++ b/www/skins/Femiwiki/Femiwiki.skin.php
@@ -50,7 +50,8 @@ class SkinFemiwiki extends SkinTemplate
             'skins.femiwiki'
         ));
         $out->addModules(array(
-            'skins.femiwiki.js'
+            'skins.femiwiki.js',
+            'skins.femiwiki.js.notification.init'
         ));
     }
 

--- a/www/skins/Femiwiki/FemiwikiTemplate.php
+++ b/www/skins/Femiwiki/FemiwikiTemplate.php
@@ -509,6 +509,31 @@ class FemiwikiTemplate extends BaseTemplate
         ));
     }
 
+    function getPersonalTools() {
+        $personal_urls = $this->get( 'personal_urls' );
+
+        // 알림과 메시지를 skins.femiwiki.js.notification.init에서만 처리할 수 있도록 
+        // Echo 확장기능에서 $( '#pt-notifications-alert-dialog a' )이나 
+        // $( '.mw-echo-notification-badge-nojs' )과 같은 방법으로 접근하는 링크들을 다른 이름으로 바꿉니다.
+        $insertUrls = [];
+        foreach ( [ 'alert', 'message' ] as $type ) {
+            if ( isset( $personal_urls["notifications-$type"] ) ) {
+                $insertUrls["notifications-$type-dialog"] = $personal_urls["notifications-$type"];
+                // 숫자 앞에 무슨 알림인지를 표기합니다.
+                $insertUrls["notifications-$type-dialog"]['text'] = ( $type == 'alert' ? '알림: ' : '메시지: ' ).$insertUrls["notifications-$type-dialog"]['text'];
+                // 아이콘이 아니라 글자를 적을 것이기에 뺍니다. (아이콘의 경우 길이가 제한됩니다.)
+                $insertUrls["notifications-$type-dialog"]['class'] = str_replace( ' oo-ui-iconElement oo-ui-iconElement-icon', '', $insertUrls["notifications-$type-dialog"]['class'] );
+                $insertUrls["notifications-$type-dialog"]['class'] = str_replace( 'mw-echo-notification-badge-nojs', 'mw-echo-notification-badge-dialog-nojs', $insertUrls["notifications-$type-dialog"]['class'] );
+                unset( $personal_urls["notifications-$type"] );
+            }    
+        }
+
+        $personal_urls = wfArrayInsertAfter( $personal_urls, $insertUrls, 'userpage' );
+        $this->set( 'personal_urls', $personal_urls );
+
+        return parent::getPersonalTools();
+    }
+
     /**
      * Outputs a css clear using the core visualClear class
      */

--- a/www/skins/Femiwiki/resources/main.js
+++ b/www/skins/Femiwiki/resources/main.js
@@ -69,13 +69,15 @@ $(function () {
 
 	// Notification badge
 	var initialNotifCount = mw.config.get( 'wgEchoInitialNotifCount' );
-	var alerts = initialNotifCount.alert;
-	var messages = initialNotifCount.message;
-	var badge = alerts + messages;
-	if (badge !== 0) {
-		$('#fw-menu-toggle .badge')
-			.addClass('active')
-			.text(badge > 10 ? '+9' : badge)
+	if( initialNotifCount != null ) {
+		var alerts = initialNotifCount.alert;
+		var messages = initialNotifCount.message;
+		var badge = alerts + messages;
+		if (badge !== 0) {
+			$('#fw-menu-toggle .badge')
+				.addClass('active')
+				.text(badge > 10 ? '+9' : badge)
+		}
 	}
 
 	// Collapsible category links

--- a/www/skins/Femiwiki/resources/main.js
+++ b/www/skins/Femiwiki/resources/main.js
@@ -1,145 +1,145 @@
 // <gtm>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-5TNKVJ');
 // </gtm>
 
 // Web-font for Windows
 // (function() {
-//   if(navigator.userAgent.indexOf('Windows') === -1) return;
+//	if(navigator.userAgent.indexOf('Windows') === -1) return;
 //
-//   var link = document.createElement('link');
-//   link.setAttribute('rel', 'stylesheet');
-//   link.setAttribute('href', '//fonts.googleapis.com/earlyaccess/notosanskr.css');
-//   document.head.appendChild(link);
+//	var link = document.createElement('link');
+//	link.setAttribute('rel', 'stylesheet');
+//	link.setAttribute('href', '//fonts.googleapis.com/earlyaccess/notosanskr.css');
+//	document.head.appendChild(link);
 // })();
 
 var _FW = {
-  BBS_NS: [3902, 3904]
+	BBS_NS: [3902, 3904]
 };
 
 
 $(function () {
-  function menuResize(divId){
-    var containerWidth = parseFloat($('#'+divId).css('width'))
-      -parseFloat($('#'+divId).css('padding-left'))
-      -parseFloat($('#'+divId).css('padding-right')),
-      itemPadding
-        =parseFloat($('#'+divId+' > div').css('padding-left'))
-        +parseFloat($('#'+divId+' > div').css('padding-right')),
-      itemMargin
-        =parseFloat($('#'+divId+' > div').css('margin-left'))
-        +parseFloat($('#'+divId+' > div').css('margin-right')),
-      itemActualMinWidth = 
-        parseFloat($('#'+divId+' > div').css('min-width'))
-        +itemPadding+itemMargin,
-      itemLength = $('#'+divId+' > div').filter(function() {
-          return $(this).css('display') !== 'none';
-      }).length,
-      horizontalCapacity = Math.min(Math.floor(containerWidth / itemActualMinWidth),itemLength);
+	function menuResize(divId){
+		var containerWidth = parseFloat($('#'+divId).css('width'))
+			-parseFloat($('#'+divId).css('padding-left'))
+			-parseFloat($('#'+divId).css('padding-right')),
+			itemPadding
+				=parseFloat($('#'+divId+' > div').css('padding-left'))
+				+parseFloat($('#'+divId+' > div').css('padding-right')),
+			itemMargin
+				=parseFloat($('#'+divId+' > div').css('margin-left'))
+				+parseFloat($('#'+divId+' > div').css('margin-right')),
+			itemActualMinWidth = 
+				parseFloat($('#'+divId+' > div').css('min-width'))
+				+itemPadding+itemMargin,
+			itemLength = $('#'+divId+' > div').filter(function() {
+					return $(this).css('display') !== 'none';
+			}).length,
+			horizontalCapacity = Math.min(Math.floor(containerWidth / itemActualMinWidth),itemLength);
 
-    $('#'+divId+' > div').css("width",Math.floor(containerWidth/horizontalCapacity-itemPadding-itemMargin));
-  }
+		$('#'+divId+' > div').css("width",Math.floor(containerWidth/horizontalCapacity-itemPadding-itemMargin));
+	}
 
-  var searchInput = $('#searchInput'),
-   searchClearButton = $('#searchClearButton');
-  searchInput.on("input", function(){
-    searchClearButton.toggle(!!this.value);
-  });
-  searchClearButton.click(function () {
-    searchInput.val("").trigger('input').focus();
-  });
+	var searchInput = $('#searchInput'),
+	 searchClearButton = $('#searchClearButton');
+	searchInput.on("input", function(){
+		searchClearButton.toggle(!!this.value);
+	});
+	searchClearButton.click(function () {
+		searchInput.val("").trigger('input').focus();
+	});
 
-  $('#fw-menu-toggle').click(function () {
-    $('#fw-menu').toggle();
-    menuResize('fw-menu');
-    $('#fw-menu-toggle .badge')
-      .removeClass('active')
-  });
-  $('#p-links-toggle').click(function () {
-    $('#p-actions-and-toolbox').toggle();
-    menuResize('p-actions-and-toolbox');
-  });
-  $(window).resize(function() {
-    menuResize('fw-menu');
-    menuResize('p-actions-and-toolbox')
-  });
+	$('#fw-menu-toggle').click(function () {
+		$('#fw-menu').toggle();
+		menuResize('fw-menu');
+		$('#fw-menu-toggle .badge')
+			.removeClass('active')
+	});
+	$('#p-links-toggle').click(function () {
+		$('#p-actions-and-toolbox').toggle();
+		menuResize('p-actions-and-toolbox');
+	});
+	$(window).resize(function() {
+		menuResize('fw-menu');
+		menuResize('p-actions-and-toolbox')
+	});
 
-  // Notification badge
-  var alerts = +$('#pt-notifications-alert').text();
-  var messages = +$('#pt-notifications-message').text();
-  var badge = alerts + messages;
-  if (badge !== 0) {
-    $('#fw-menu-toggle .badge')
-      .addClass('active')
-      .text(badge > 10 ? '+9' : badge)
-  }
+	// Notification badge
+	var alerts = +$('#pt-notifications-alert').text();
+	var messages = +$('#pt-notifications-message').text();
+	var badge = alerts + messages;
+	if (badge !== 0) {
+		$('#fw-menu-toggle .badge')
+			.addClass('active')
+			.text(badge > 10 ? '+9' : badge)
+	}
 
-  $('#pt-notifications-alert a').text('알림: ' + alerts);
-  $('#pt-notifications-message a').text('메시지: ' + messages);
+	$('#pt-notifications-alert a').text('알림: ' + alerts);
+	$('#pt-notifications-message a').text('메시지: ' + messages);
 
-  // Collapsible category links
-  var catlinksToggle = $('<button></button>');
-  catlinksToggle.text("►");
-  catlinksToggle.addClass('fw-catlinks-toggle');
+	// Collapsible category links
+	var catlinksToggle = $('<button></button>');
+	catlinksToggle.text("►");
+	catlinksToggle.addClass('fw-catlinks-toggle');
 
-  var catlinks = $('#mw-normal-catlinks li'),
-    directCatAnchors = $('#fw-catlinks li>a'),
-    directCatTexts = {};
-  for(var i=0,len=directCatAnchors.length;i<len;i++)
-    directCatTexts[directCatAnchors[i].text] = true;
+	var catlinks = $('#mw-normal-catlinks li'),
+		directCatAnchors = $('#fw-catlinks li>a'),
+		directCatTexts = {};
+	for(var i=0,len=directCatAnchors.length;i<len;i++)
+		directCatTexts[directCatAnchors[i].text] = true;
 
-  if(directCatAnchors.length !== catlinks.length) {
-    for(var i=0,len=catlinks.length;i<len;i++)
-      if( !directCatTexts[catlinks[i].innerText] )
-       catlinks[i].className += ' collapsible' ;
+	if(directCatAnchors.length !== catlinks.length) {
+		for(var i=0,len=catlinks.length;i<len;i++)
+			if( !directCatTexts[catlinks[i].innerText] )
+			 catlinks[i].className += ' collapsible' ;
 
-    $('#catlinks li.collapsible').fadeOut();
-    var collapsed = true;
-    catlinksToggle.click(function () {
-      $(this).text($(this).text() == "▼" ? "►" : "▼");
-      if(collapsed)
-        $('#catlinks li.collapsible').fadeIn();
-      else
-        $('#catlinks li.collapsible').fadeOut();
-      collapsed = !collapsed;
-    });
-    $('#mw-normal-catlinks').prepend(catlinksToggle);
-  }
+		$('#catlinks li.collapsible').fadeOut();
+		var collapsed = true;
+		catlinksToggle.click(function () {
+			$(this).text($(this).text() == "▼" ? "►" : "▼");
+			if(collapsed)
+				$('#catlinks li.collapsible').fadeIn();
+			else
+				$('#catlinks li.collapsible').fadeOut();
+			collapsed = !collapsed;
+		});
+		$('#mw-normal-catlinks').prepend(catlinksToggle);
+	}
 
-  // Do not show edit page when user clicks red link
-  $('#bodyContent a').each(function() {
-    this.href = this.href.replace('&action=edit&redlink=1', '&redlink=1');
-  });
+	// Do not show edit page when user clicks red link
+	$('#bodyContent a').each(function() {
+		this.href = this.href.replace('&action=edit&redlink=1', '&redlink=1');
+	});
 
-  // Open external links in new tab
-  $('#bodyContent a').each(function() {
-    var external = this.href.match('^https?://') && !this.href.match('^https?://' + location.hostname);
-    if(external) {
-      $(this)
-        .addClass('external')
-        .attr('target', '_blank');
-    } else {
-      $(this).removeClass('external');
-    }
-  })
-  // Set Mathjax linebreaks configuration
-  MathJax.Hub.Config({
-    CommonHTML: { linebreaks: { automatic: true } },
-    "HTML-CSS": { linebreaks: { automatic: true } },
-           SVG: { linebreaks: { automatic: true } }
-  });
+	// Open external links in new tab
+	$('#bodyContent a').each(function() {
+		var external = this.href.match('^https?://') && !this.href.match('^https?://' + location.hostname);
+		if(external) {
+			$(this)
+				.addClass('external')
+				.attr('target', '_blank');
+		} else {
+			$(this).removeClass('external');
+		}
+	})
+	// Set Mathjax linebreaks configuration
+	MathJax.Hub.Config({
+		CommonHTML: { linebreaks: { automatic: true } },
+		"HTML-CSS": { linebreaks: { automatic: true } },
+					 SVG: { linebreaks: { automatic: true } }
+	});
 
-  // Center single Mathjax line
-  MathJax.Hub.Queue(function () {
-    $('#content p > span:only-child > span.MathJax,'
-    +'#content p > span.mathjax-wrapper:only-child > div').each(function(){
-      if(!$(this).parent().parent().clone().children().remove().end().text().trim().length) {
-        $(this).parent().css('display','block');
-        $(this).parent().css('text-align','center');
-      }
-    });
-  });
+	// Center single Mathjax line
+	MathJax.Hub.Queue(function () {
+		$('#content p > span:only-child > span.MathJax,'
+		+'#content p > span.mathjax-wrapper:only-child > div').each(function(){
+			if(!$(this).parent().parent().clone().children().remove().end().text().trim().length) {
+				$(this).parent().css('display','block');
+				$(this).parent().css('text-align','center');
+			}
+		});
+	});
 });

--- a/www/skins/Femiwiki/resources/main.js
+++ b/www/skins/Femiwiki/resources/main.js
@@ -8,12 +8,12 @@
 
 // Web-font for Windows
 // (function() {
-//	if(navigator.userAgent.indexOf('Windows') === -1) return;
+//	 if(navigator.userAgent.indexOf('Windows') === -1) return;
 //
-//	var link = document.createElement('link');
-//	link.setAttribute('rel', 'stylesheet');
-//	link.setAttribute('href', '//fonts.googleapis.com/earlyaccess/notosanskr.css');
-//	document.head.appendChild(link);
+//	 var link = document.createElement('link');
+//	 link.setAttribute('rel', 'stylesheet');
+//	 link.setAttribute('href', '//fonts.googleapis.com/earlyaccess/notosanskr.css');
+//	 document.head.appendChild(link);
 // })();
 
 var _FW = {
@@ -68,17 +68,15 @@ $(function () {
 	});
 
 	// Notification badge
-	var alerts = +$('#pt-notifications-alert').text();
-	var messages = +$('#pt-notifications-message').text();
+	var initialNotifCount = mw.config.get( 'wgEchoInitialNotifCount' );
+	var alerts = initialNotifCount.alert;
+	var messages = initialNotifCount.message;
 	var badge = alerts + messages;
 	if (badge !== 0) {
 		$('#fw-menu-toggle .badge')
 			.addClass('active')
 			.text(badge > 10 ? '+9' : badge)
 	}
-
-	$('#pt-notifications-alert a').text('알림: ' + alerts);
-	$('#pt-notifications-message a').text('메시지: ' + messages);
 
 	// Collapsible category links
 	var catlinksToggle = $('<button></button>');
@@ -125,6 +123,7 @@ $(function () {
 			$(this).removeClass('external');
 		}
 	})
+
 	// Set Mathjax linebreaks configuration
 	MathJax.Hub.Config({
 		CommonHTML: { linebreaks: { automatic: true } },

--- a/www/skins/Femiwiki/resources/mw.femiwiki.NotificationBadgeWidget.js
+++ b/www/skins/Femiwiki/resources/mw.femiwiki.NotificationBadgeWidget.js
@@ -1,0 +1,406 @@
+( function ( mw, $ ) {
+	/**
+	 * Notification 배지 버튼과 dialog.
+	 * Echo 확장기능의 mw.echo.ui.NotificationBadgeWidget을 복사한 뒤 변형하였습니다.
+	 *
+	 * @class
+	 * @extends OO.ui.ButtonWidget
+	 *
+	 * @constructor
+	 * @param {mw.echo.dm.NotificationsModel} model Notifications view model
+	 * @param {mw.echo.dm.UnreadNotificationCounter} unreadCounter Counter of unread notifications
+ 	 * @param {Object} [config] Configuration object
+	 * @cfg {number} [numItems=0] How many items are in the button display
+	 * @cfg {boolean} [hasUnseen=false] Whether there are unseen items
+	 * @cfg {boolean} [markReadWhenSeen=false] Mark all notifications as read on open
+	 * @cfg {string|Object} [badgeIcon] The icons to use for this button.
+	 *	If this is a string, it will be used as the icon regardless of the state.
+	 *	If it is an object, it must include
+	 *	the properties 'unseen' and 'seen' with icons attached to both. For example:
+	 *	{ badgeIcon: {
+	 *		unseen: 'bellOn',
+	 *		seen: 'bell'
+	 *	} }
+	 * @cfg {string} [href] URL the badge links to
+	 * @cfg {jQuery} [$overlay] A jQuery element functioning as an overlay
+	 *	for dialogs.
+	 */
+	mw.femiwiki.NotificationBadgeWidget = function MwFemiwikiNotificationBadgeButtonDialogWidget( model, unreadCounter, config ) {
+		var buttonFlags, allNotificationsButton, preferencesButton, footerButtonGroupWidget, 
+			initialNotifCount, notice,
+			widget = this;
+
+		config = config || {};
+		config.links = config.links || {};
+
+		// Parent constructor
+		mw.femiwiki.NotificationBadgeWidget.parent.call( this, config );
+
+		// Mixin constructors
+		OO.ui.mixin.PendingElement.call( this, config );
+
+		this.$overlay = config.$overlay || this.$element;
+		// Create a menu overlay
+		this.$menuOverlay = $( '<div>' )
+			.addClass( 'mw-echo-ui-NotificationBadgeWidget-overlay-menu' );
+		this.$overlay.append( this.$menuOverlay );
+
+		// View model
+		this.notificationsModel = model;
+		this.unreadCounter = unreadCounter;
+		this.type = this.notificationsModel.getType();
+
+		this.maxNotificationCount = mw.config.get( 'wgEchoMaxNotificationCount' );
+		this.numItems = config.numItems || 0;
+		this.markReadWhenSeen = !!config.markReadWhenSeen;
+		this.badgeIcon = config.badgeIcon || {};
+		this.hasRunFirstTime = false;
+
+		buttonFlags = [ 'primary' ];
+		if ( !!config.hasUnseen ) {
+			buttonFlags.push( 'unseen' );
+		}
+
+		this.badgeButton = new mw.echo.ui.BadgeLinkWidget( {
+			label: this.numItems,
+			flags: buttonFlags,
+			badgeIcon: config.badgeIcon,
+			// The following messages can be used here:
+			// tooltip-pt-notifications-alert
+			// tooltip-pt-notifications-message
+			title: mw.msg( 'tooltip-pt-notifications-' + this.type ),
+			href: config.href
+		} );
+
+		// Notifications widget
+		this.notificationsWidget = new mw.echo.ui.NotificationsWidget(
+			this.notificationsModel,
+			{
+				type: this.type,
+				$overlay: this.$menuOverlay,
+				markReadWhenSeen: this.markReadWhenSeen
+			}
+		);
+
+		// Footer
+		allNotificationsButton = new OO.ui.ButtonWidget( {
+			icon: 'next',
+			label: mw.msg( 'echo-overlay-link' ),
+			href: config.links.notifications,
+			classes: [ 'mw-echo-ui-notificationBadgeButtonDialogWidget-footer-allnotifs' ]
+		} );
+
+		preferencesButton = new OO.ui.ButtonWidget( {
+			icon: 'advanced',
+			label: mw.msg( 'mypreferences' ),
+			href: config.links.preferences,
+			classes: [ 'mw-echo-ui-notificationBadgeButtonDialogWidget-footer-preferences' ]
+		} );
+
+		footerButtonGroupWidget = new OO.ui.ButtonGroupWidget( {
+			items: [ allNotificationsButton, preferencesButton ],
+			classes: [ 'mw-echo-ui-notificationBadgeButtonDialogWidget-footer-buttons' ]
+		} );
+		this.$footer = $( '<div>' )
+			.addClass( 'mw-echo-ui-notificationBadgeButtonDialogWidget-footer' )
+			.append( footerButtonGroupWidget.$element );
+
+		// Footer notice
+		initialNotifCount = mw.config.get( 'wgEchoInitialNotifCount' );
+		initialNotifCount = this.type === 'all' ? ( initialNotifCount.alert + initialNotifCount.message ) : initialNotifCount[ this.type ];
+		if (
+			mw.config.get( 'wgEchoShowBetaInvitation' ) &&
+			!mw.user.options.get( 'echo-dismiss-beta-invitation' )
+		) {
+			notice = new mw.echo.ui.FooterNoticeWidget( {
+				// This is probably not the right way of doing this
+				iconUrl: mw.config.get( 'wgExtensionAssetsPath' ) + '/Echo/modules/icons/feedback.svg',
+				url: mw.util.getUrl( 'Special:Preferences' ) + '#mw-prefsection-betafeatures'
+			} );
+			// Event
+			notice.connect( this, { dismiss: 'onFooterNoticeDismiss' } );
+			// Prepend to the footer
+			this.$footer.prepend( notice.$element );
+		}
+
+		function NotificationDialog( config ) {
+			NotificationDialog.super.call( this, config );
+		}
+		OO.inheritClass( NotificationDialog, OO.ui.ProcessDialog ); 
+
+		// Specify a name for .addWindows()
+		NotificationDialog.static.name = this.type+'Dialog';
+		// Specify a title.
+		NotificationDialog.static.title = mw.msg( 'echo-notification-' + this.type + '-text-only' );
+		NotificationDialog.static.actions = [
+			{ 
+				action: 'markAllRead',
+				modes: 'edit',
+				label: mw.msg( 'echo-mark-all-as-read' ),
+				flags: [ 'primary', 'constructive' ],
+				classes: [ 'mw-echo-ui-notificationsWidget-markAllReadButton' ]
+			},
+			{ modes: 'edit', label: '닫기', flags: 'safe' }
+		];
+
+		NotificationDialog.prototype.initialize = function () {
+			// Call the parent method
+			NotificationDialog.super.prototype.initialize.call( this );
+		};
+			
+		// Override the getBodyHeight() method to specify a custom height (or don't to use the automatically generated height)
+		NotificationDialog.prototype.getBodyHeight = function () {
+			// return this.panel1.$element.outerHeight( true ); // 자동으로 할 경우 매우 짧아집니다.
+			return 450;
+		};
+
+		NotificationDialog.prototype.initialize = function () {
+			NotificationDialog.parent.prototype.initialize.apply( this, arguments );
+			this.content = widget.notificationsWidget;
+			this.$body.append( this.content.$element );
+			this.$foot.append( widget.$footer );
+		};
+
+		NotificationDialog.prototype.getActionProcess = function ( action ) {
+			var dialog = this;
+			if ( action === 'markAllRead' ) {
+				return new OO.ui.Process( function () {
+					widget.notificationsModel.markAllRead();
+				} );
+			}
+		// Fallback to parent handler.
+			return NotificationDialog.super.prototype.getActionProcess.call( this, action );
+		};
+
+		// Make the window.
+		this.dialog = new NotificationDialog( {
+			size: 'medium'
+		} );
+
+		// Add the window to the window manager using the addWindows() method.
+		mw.femiwiki.NotificationBadgeWidget.static.windowManager.addWindows( [ this.dialog ] );
+
+		this.updateIcon( !!config.hasUnseen );
+
+		// 모두 읽음으로 표시 버튼을 우선 비활성화합니다.
+		this.dialog.getActions().setAbilities( { markAllRead: false } );
+
+		// Events
+		this.notificationsModel.connect( this, {
+			updateSeenTime: 'updateBadge',
+			unseenChange: 'updateBadge'
+		} );
+		this.unreadCounter.connect( this, { countChange: 'updateBadge' } );
+		mw.femiwiki.NotificationBadgeWidget.static.windowManager.connect( this, {
+			opening: 'onDialogOpening',
+			closing: 'onDialogClosing'
+		} );
+		this.badgeButton.connect( this, {
+			click: 'onBadgeButtonClick'
+		} );
+
+		this.$element
+			.prop( 'id', 'pt-notifications-' + this.type )
+			// The following classes can be used here:
+			// mw-echo-ui-notificationBadgeButtonDialogWidget-alert
+			// mw-echo-ui-notificationBadgeButtonDialogWidget-message
+			.addClass(
+				'mw-echo-ui-notificationBadgeButtonDialogWidget ' +
+				'mw-echo-ui-notificationBadgeButtonDialogWidget-' + this.type
+			)
+			.append(
+				this.badgeButton.$element
+			);
+	};
+
+	/* Initialization */
+
+	OO.inheritClass( mw.femiwiki.NotificationBadgeWidget, OO.ui.Widget );
+	OO.mixinClass( mw.femiwiki.NotificationBadgeWidget, OO.ui.mixin.PendingElement );
+
+	/* Static properties */
+
+	mw.femiwiki.NotificationBadgeWidget.static.tagName = 'li';
+
+	if ( !mw.femiwiki.NotificationBadgeWidget.static.windowManager ) {
+		mw.femiwiki.NotificationBadgeWidget.static.windowManager = new OO.ui.WindowManager();
+		$( 'body' ).append( mw.femiwiki.NotificationBadgeWidget.static.windowManager.$element );
+	}
+
+	/* Events */
+
+	/**
+	 * @event allRead
+	 * All notifications were marked as read
+	 */
+
+	/**
+	 * @event finishLoading
+	 * Notifications have successfully finished being processed and are fully loaded
+	 */
+
+	/* Methods */
+
+	mw.femiwiki.NotificationBadgeWidget.prototype.onFooterNoticeDismiss = function () {
+
+		// Save the preference in general
+		new mw.Api().saveOption( 'echo-dismiss-beta-invitation', 1 );
+		// Save the preference for this session
+		mw.user.options.set( 'echo-dismiss-beta-invitation', 1 );
+	};
+
+	/**
+	 * Respond to badge button click
+	 */
+	mw.femiwiki.NotificationBadgeWidget.prototype.onBadgeButtonClick = function () {
+		this.notificationsModel.fetchNotifications( true );
+		mw.femiwiki.NotificationBadgeWidget.static.windowManager.openWindow( this.dialog );
+	};
+
+	/**
+	 * Update the badge icon with the read/unread versions if they exist.
+	 *
+	 * @param {boolean} hasUnseen Widget has unseen notifications
+	 */
+	mw.femiwiki.NotificationBadgeWidget.prototype.updateIcon = function ( hasUnseen ) {
+		var icon = typeof this.badgeIcon === 'string' ?
+			this.badgeIcon :
+			this.badgeIcon[ hasUnseen ? 'unseen' : 'seen' ];
+
+		this.badgeButton.setIcon( icon );
+	};
+
+	// Client-side version of NotificationController::getCappedNotificationCount.
+	/**
+	 * Gets the count to use for display
+	 *
+	 * @param {number} count Count before cap is applied
+	 *
+	 * @return {number} Count with cap applied
+	 */
+	mw.femiwiki.NotificationBadgeWidget.prototype.getCappedNotificationCount = function ( count ) {
+		if ( count <= this.maxNotificationCount ) {
+			return count;
+		} else {
+			return this.maxNotificationCount + 1;
+		}
+	};
+
+	/**
+	 * Update the badge state and label based on changes to the model
+	 */
+	mw.femiwiki.NotificationBadgeWidget.prototype.updateBadge = function () {
+		var unseenCount = this.notificationsModel.getUnseenCount(),
+			unreadCount = this.unreadCounter.getCount(),
+			nonBundledUnreadCount = this.notificationsModel.getNonbundledUnreadCount(),
+			cappedUnreadCount,
+			badgeLabel;
+
+		// Update numbers and seen/unseen state
+		// If the dialog is open, only allow a "demotion" of the badge
+		// to grey; ignore change of color to 'unseen'
+		if ( mw.femiwiki.NotificationBadgeWidget.static.windowManager.isVisible() ) {
+			if ( !unseenCount ) {
+				this.badgeButton.setFlags( { unseen: false } );
+				this.updateIcon( false );
+			}
+		} else {
+			this.badgeButton.setFlags( { unseen: !!unseenCount } );
+			this.updateIcon( !!unseenCount );
+		}
+
+		// Update badge count
+		cappedUnreadCount = this.getCappedNotificationCount( unreadCount );
+		cappedUnreadCount = mw.language.convertNumber( cappedUnreadCount );
+		badgeLabel = mw.message( 'echo-badge-count', cappedUnreadCount ).text();
+		this.badgeButton.setLabel( (this.type == 'alert' ? '알림: ' : '메시지: ') +badgeLabel );
+
+		// Check if we need to display the 'mark all unread' button
+		this.dialog.getActions().setAbilities( { markAllRead: !this.markReadWhenSeen && nonBundledUnreadCount > 0 } );
+	};
+
+	mw.femiwiki.NotificationBadgeWidget.prototype.onDialogOpening = function ( win, opened, data ) {
+		var widget = this;
+
+		if ( this.promiseRunning ) {
+			return;
+		}
+
+		// Log the click event
+		mw.echo.logger.logInteraction(
+			'ui-badge-link-click',
+			mw.echo.Logger.static.context.badge,
+			null,
+			this.type
+		);
+
+		this.pushPending();
+		this.dialog.getActions().setAbilities( { markAllRead: false } );
+		this.promiseRunning = true;
+
+		this.notificationsModel.fetchNotifications()
+			.then( function () {
+				// Update seen time
+				widget.notificationsModel.updateSeenTime();
+				// Mark notifications as 'read' if markReadWhenSeen is set to true
+				if ( widget.markReadWhenSeen ) {
+					widget.notificationsModel.autoMarkAllRead();
+				}
+
+				widget.emit( 'finishLoading' );
+			} )
+			.always( function () {
+				// Pop pending
+				widget.popPending();
+				widget.promiseRunning = false;
+			} );
+		this.hasRunFirstTime = true;
+	};
+
+	mw.femiwiki.NotificationBadgeWidget.prototype.onDialogClosing = function ( win, opened, data ) {
+		var widget = this;
+
+		if ( this.promiseRunning ) {
+			return;
+		}
+
+		// Remove "initiallyUnseen" and leave
+		this.notificationsWidget.resetNotificationItems();
+
+		if ( this.promiseRunning ) {
+			return;
+		}
+		// Log the click event
+		mw.echo.logger.logInteraction(
+			'ui-badge-link-click',
+			mw.echo.Logger.static.context.badge,
+			null,
+			this.type
+		);
+
+		this.pushPending();
+		this.dialog.getActions().setAbilities( { markAllRead: false } );
+		this.promiseRunning = true;
+
+		this.notificationsModel.fetchNotifications()
+			.then( function () {
+				widget.emit( 'finishLoading' );
+			} )
+			.always( function () {
+				// Pop pending
+				widget.popPending();
+				widget.promiseRunning = false;
+			} );
+		this.hasRunFirstTime = true;
+	};
+
+	/**
+	 * Get the notifications model attached to this widget
+	 *
+	 * @return {mw.echo.dm.NotificationsModel} Notifications model
+	 */
+	mw.femiwiki.NotificationBadgeWidget.prototype.getModel = function () {
+		return this.notificationsModel;
+	};
+
+} )( mediaWiki, jQuery );

--- a/www/skins/Femiwiki/resources/mw.femiwiki.js
+++ b/www/skins/Femiwiki/resources/mw.femiwiki.js
@@ -1,0 +1,3 @@
+( function ( mw, $ ) {
+	mw.femiwiki = mw.femiwiki || {};
+} )( mediaWiki, jQuery );

--- a/www/skins/Femiwiki/resources/notification.init.js
+++ b/www/skins/Femiwiki/resources/notification.init.js
@@ -1,0 +1,140 @@
+/**
+ * Echo 확장기능의 ext.echo.init.js를 복사한 후 변형했습니다.
+ */
+( function ( mw, $ ) {
+	'use strict';
+
+	// Remove ?markasread=XYZ from the URL
+	var uri = new mw.Uri();
+	if ( uri.query.markasread !== undefined ) {
+		delete uri.query.markasread;
+		window.history.replaceState( null, document.title, uri );
+	}
+
+	mw.echo = mw.echo || {};
+
+	// Activate ooui
+	$( document ).ready( function () {
+		var myWidget, echoApi,
+			$existingAlertLink = $( '#pt-notifications-alert-dialog a' ),
+			$existingMessageLink = $( '#pt-notifications-message-dialog a' ),
+			numAlerts = $existingAlertLink.text(),
+			numMessages = $existingMessageLink.text(),
+			hasUnseenAlerts = $existingAlertLink.hasClass( 'mw-echo-unseen-notifications' ),
+			hasUnseenMessages = $existingMessageLink.hasClass( 'mw-echo-unseen-notifications' ),
+			// Store links
+			links = {
+				notifications: $( '#pt-notifications-alert-dialog a' ).attr( 'href' ),
+				preferences: $( '#pt-preferences a' ).attr( 'href' ) + '#mw-prefsection-echo'
+			};
+
+		// Respond to click on the notification button and load the UI on demand
+		$( '.mw-echo-notification-badge-dialog-nojs' ).click( function ( e ) {
+			var myType = $( this ).parent().prop( 'id' ) === 'pt-notifications-alert-dialog' ? 'alert' : 'message',
+				time = mw.now();
+
+			if ( e.which !== 1 ) {
+				return;
+			}
+
+			// Dim the button while we load
+			$( this ).addClass( 'mw-echo-notifications-badge-dimmed' );
+
+			// Fire the notification API requests
+			echoApi = new mw.echo.api.EchoApi();
+			echoApi.fetchNotifications( myType )
+				.then( function ( data ) {
+					mw.track( 'timing.MediaWiki.echo.overlay.api', mw.now() - time );
+					return data;
+				} );
+
+			// Load the ui
+			mw.loader.using( [ 'skins.femiwiki.js.ui.notification' ] , function () {
+				var messageNotificationsModel,
+					alertNotificationsModel,
+					unreadMessageCounter,
+					unreadAlertCounter,
+					maxNotificationCount = mw.config.get( 'wgEchoMaxNotificationCount' );
+
+				// Overlay
+				$( 'body' ).append( mw.echo.ui.$overlay );
+
+				// Load message button and popup if messages exist
+				if ( $existingMessageLink.length ) {
+					unreadMessageCounter = new mw.echo.dm.UnreadNotificationCounter( echoApi, 'message', maxNotificationCount );
+					messageNotificationsModel = new mw.echo.dm.NotificationsModel(
+						echoApi,
+						unreadMessageCounter,
+						{
+							type: 'message'
+						}
+					);
+					mw.echo.ui.messageWidget = new mw.femiwiki.NotificationBadgeWidget( messageNotificationsModel, unreadMessageCounter, {
+						markReadWhenSeen: false,
+						$overlay: mw.echo.ui.$overlay,
+						numItems: numMessages,
+						hasUnseen: hasUnseenMessages,
+						badgeIcon: 'speechBubbles',
+						links: links,
+						href: $existingMessageLink.attr( 'href' )
+					} );
+					// HACK: avoid late debouncedUpdateThemeClasses
+					mw.echo.ui.messageWidget.badgeButton.debouncedUpdateThemeClasses();
+					// Replace the link button with the ooui button
+					$existingMessageLink.parent().replaceWith( mw.echo.ui.messageWidget.$element );
+
+					mw.echo.ui.messageWidget.getModel().on( 'allTalkRead', function () {
+						// If there was a talk page notification, get rid of it
+						$( '#pt-mytalk a' )
+							.removeClass( 'mw-echo-alert' )
+							.text( mw.msg( 'mytalk' ) );
+					} );
+				}
+				// Load alerts popup and button
+				unreadAlertCounter = new mw.echo.dm.UnreadNotificationCounter( echoApi, 'alert', maxNotificationCount );
+				alertNotificationsModel = new mw.echo.dm.NotificationsModel(
+					echoApi,
+					unreadAlertCounter,
+					{
+						type: 'alert'
+					}
+				);
+				mw.echo.ui.alertWidget = new mw.femiwiki.NotificationBadgeWidget( alertNotificationsModel, unreadAlertCounter, {
+					markReadWhenSeen: true,
+					numItems: numAlerts,
+					hasUnseen: hasUnseenAlerts,
+					badgeIcon: {
+						seen: 'bell',
+						unseen: 'bellOn'
+					},
+					links: links,
+					$overlay: mw.echo.ui.$overlay,
+					href: $existingAlertLink.attr( 'href' )
+				} );
+				// HACK: avoid late debouncedUpdateThemeClasses
+				mw.echo.ui.alertWidget.badgeButton.debouncedUpdateThemeClasses();
+				// Replace the link button with the ooui button
+				$existingAlertLink.parent().replaceWith( mw.echo.ui.alertWidget.$element );
+
+				// HACK: Now that the module loaded, show the popup
+				myWidget = myType === 'alert' ? mw.echo.ui.alertWidget : mw.echo.ui.messageWidget;
+				myWidget.once( 'finishLoading', function () {
+					// Log timing after notifications are shown
+					mw.track( 'timing.MediaWiki.echo.overlay', mw.now() - time );
+				} );
+				mw.femiwiki.NotificationBadgeWidget.static.windowManager.openWindow( myWidget.dialog );
+
+				mw.track( 'timing.MediaWiki.echo.overlay.ooui', mw.now() - time );
+			} );
+
+			if ( hasUnseenAlerts || hasUnseenMessages ) {
+				// Clicked on the flyout due to having unread notifications
+				mw.track( 'counter.MediaWiki.echo.unseen.click' );
+			}
+
+			// Prevent default
+			return false;
+		} );
+	} );
+
+} )( mediaWiki, jQuery );

--- a/www/skins/Femiwiki/skin.json
+++ b/www/skins/Femiwiki/skin.json
@@ -1,75 +1,75 @@
 {
-  "name": "Femiwiki",
-  "version": "1.0",
-  "author": "...",
-  "url": "https://github.com/femiwiki/femiwiki.com/tree/master/www/skins/Femiwiki",
-  "descriptionmsg": "femiwiki-desc",
-  "namemsg": "skinname-femiwiki",
-  "license-name": "CC0-1.0",
-  "type": "skin",
-  "ValidSkinNames": {
-    "femiwiki": "Femiwiki"
-  },
-  "MessagesDirs": {
-    "Femiwiki": [
-      "i18n"
-    ]
-  },
-  "ResourceModules": {
-    "skins.femiwiki": {
-      "class": "ResourceLoaderSkinModule",
-      "position": "top",
-      "styles": {
-        "resources/libraries/normalise.css": {
-          "media": "screen"
-        },
-        "resources/screen-common.less": {
-          "media": "screen"
-        },
-        "resources/screen-dialog.less": {
-          "media": "screen"
-        },
-        "resources/screen-table.less": {
-          "media": "screen"
-        },
-        "resources/screen-gnb.less": {
-          "media": "screen"
-        },
-        "resources/screen-changes.less": {
-          "media": "screen"
-        },
-        "resources/screen-bbs.less": {
-          "media": "screen"
-        },
-        "resources/screen-category.less": {
-          "media": "screen"
-        },
-        "resources/screen-flow.less": {
-          "media": "screen"
-        },
-        "resources/print.css": {
-          "media": "print"
-        }
-      }
-    },
-    "skins.femiwiki.js": {
-      "position": "bottom",
-      "scripts": [
-        "resources/main.js",
-        "resources/mute.js",
-        "resources/share.js",
-        "resources/recentchanges.js",
-        "resources/bbs.js"
-      ]
-    }
-  },
-  "ResourceFileModulePaths": {
-    "localBasePath": "",
-    "remoteSkinPath": "Femiwiki"
-  },
-  "AutoloadClasses": {
-    "SkinFemiwiki": "Femiwiki.skin.php",
-    "FemiwikiTemplate": "FemiwikiTemplate.php"
-  },
-  "manifest_version": 1
+	"name": "Femiwiki",
+	"version": "1.0",
+	"author": "...",
+	"url": "https://github.com/femiwiki/femiwiki.com/tree/master/www/skins/Femiwiki",
+	"descriptionmsg": "femiwiki-desc",
+	"namemsg": "skinname-femiwiki",
+	"license-name": "CC0-1.0",
+	"type": "skin",
+	"ValidSkinNames": {
+		"femiwiki": "Femiwiki"
+	},
+	"MessagesDirs": {
+		"Femiwiki": [
+			"i18n"
+		]
+	},
+	"ResourceModules": {
+		"skins.femiwiki": {
+			"class": "ResourceLoaderSkinModule",
+			"position": "top",
+			"styles": {
+				"resources/libraries/normalise.css": {
+					"media": "screen"
+				},
+				"resources/screen-common.less": {
+					"media": "screen"
+				},
+				"resources/screen-dialog.less": {
+					"media": "screen"
+				},
+				"resources/screen-table.less": {
+					"media": "screen"
+				},
+				"resources/screen-gnb.less": {
+					"media": "screen"
+				},
+				"resources/screen-changes.less": {
+					"media": "screen"
+				},
+				"resources/screen-bbs.less": {
+					"media": "screen"
+				},
+				"resources/screen-category.less": {
+					"media": "screen"
+				},
+				"resources/screen-flow.less": {
+					"media": "screen"
+				},
+				"resources/print.css": {
+					"media": "print"
+				}
+			}
+		},
+		"skins.femiwiki.js": {
+			"position": "bottom",
+			"scripts": [
+				"resources/main.js",
+				"resources/mute.js",
+				"resources/share.js",
+				"resources/recentchanges.js",
+				"resources/bbs.js"
+			]
+		}
+	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "",
+		"remoteSkinPath": "Femiwiki"
+	},
+	"AutoloadClasses": {
+		"SkinFemiwiki": "Femiwiki.skin.php",
+		"FemiwikiTemplate": "FemiwikiTemplate.php"
+	},
+	"manifest_version": 1
 }

--- a/www/skins/Femiwiki/skin.json
+++ b/www/skins/Femiwiki/skin.json
@@ -61,6 +61,25 @@
 				"resources/recentchanges.js",
 				"resources/bbs.js"
 			]
+		},
+		"skins.femiwiki.js.notification.init": {
+			"scripts": [
+				"resources/notification.init.js"
+			],
+			"dependencies": [
+				"ext.echo.api",
+				"mediawiki.Uri"
+			]
+		},
+		"skins.femiwiki.js.ui.notification": {
+			"scripts": [
+				"resources/mw.femiwiki.js",
+				"resources/mw.femiwiki.NotificationBadgeWidget.js"
+			],
+			"dependencies": [
+				"oojs-ui",
+				"ext.echo.ui.desktop"
+			]
 		}
 	},
 	"ResourceFileModulePaths": {


### PR DESCRIPTION
- #98 을 위한 수정입니다.
- 사이트 메뉴의 알림이나 메시지를 누르면 팝업(툴팁 같이 생긴 것)을 띄우는 대신 Dialog가 뜨도록 수정합니다.
- 알림을 클릭하면 "알림: "이나 "메시지: " 글자가 사라지는 문제도 같이 수정합니다.
- PR에서 코드의 들여쓰기를 탭 문자로 변환한 것으로 인해 파일 변화를 보기가 어려울 것 같아 commit을 두 번에 나누어서 하였습니다, 참고 바랍니다.