### PR TITLE
Fix #160 검색결과 줄바꿈 오류 수정

### DIFF
--- a/www/skins/Femiwiki/resources/screen-common.less
+++ b/www/skins/Femiwiki/resources/screen-common.less
@@ -850,6 +850,10 @@ html.ve-active {
 // Search
 #content .mw-search-results {
   max-width: 100%;
+  div.searchresult {
+    width: inherit;
+    max-width: 38em;
+  }
 }
 
 #content #mw-search-top-table {


### PR DESCRIPTION
- 모바일 검색 결과 화면내 `div.searchresult`의 고정된 가로 길이(`38em`)로 인한 줄바꿈 오류  수정
- `div.searchresult`의 `width` 값을 `inherit`으로 변경하고 `max-width: 38em`으로 지정