### PR TITLE
Fix #75 특:환경설정 모바일 레이아웃 수정

### DIFF
--- a/www/skins/Femiwiki/resources/screen-common.less
+++ b/www/skins/Femiwiki/resources/screen-common.less
@@ -761,15 +761,25 @@ ul#preftoc {
 }
 
 #mw-prefs-form {
-  min-width: 56rem;
-
   .prefsection {
     border-width: 0;
     padding: 0;
     margin: 0;
-
     & > legend {
       display: none;
+    }
+    @media screen and (max-width: 480px) {
+      .mw-input {
+        word-break: break-all;
+        input,
+        select {
+          width: 100%;
+        }
+        input[type="checkbox"],
+        input[type="radio"] {
+          width: 1rem;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- 모바일에서 [특:환경설정 페이지](https://femiwiki.com/w/특수:환경설정)  가로 스크롤 생기는 문제 해결
- `#mv-prefs-form`의 최소 가로길이(`56rem`) 삭제
- 가로길이 `480px` 미만의 화면에서 `input`, `select` 엘리먼트 크기 조정
- `input`, `select`의 고정 크기를 `100%`로 변경
- `100%`가 아닌 적절한 길이로 변경할 필요가 있을 수 있음
- 긴 단어(주시문서목록토큰) 레이아웃 오류 해결: `word-break: break-all`