### PR TITLE
oo-ui-toolbar-bar CSS 제거

### DIFF
--- a/www/skins/Femiwiki/resources/screen-common.less
+++ b/www/skins/Femiwiki/resources/screen-common.less
@@ -842,10 +842,6 @@ html.ve-active {
     }
   }
 
-  .oo-ui-toolbar-bar * {
-    box-sizing: content-box;
-  }
-
   .oo-ui-toolbar {
     font-size: 12px;
   }


### PR DESCRIPTION
시각편집기 툴바의 단축키가 자리 밖으로 나와 보이는 문제가 있음