### PR TITLE
Interwiki 확장기능 활성화

### DIFF
--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -158,6 +158,7 @@ $wgGroupPermissions['bureaucrat']['usermerge'] = true;
 $wgGroupPermissions['bureaucrat']['renameuser'] = true;
 $wgGroupPermissions['sysop']['deletelogentry'] = true;
 $wgGroupPermissions['sysop']['deleterevision'] = true;
+$wgGroupPermissions['sysop']['interwiki'] = true;
 
 ## Prevent anonymous users from edit pages
 $wgGroupPermissions['*']['edit'] = false;
@@ -292,6 +293,9 @@ wfLoadExtension( 'Echo' );
 ## TwoColConflict
 wfLoadExtension( 'TwoColConflict' );
 $wgDefaultUserOptions['twocolconft'] = true;
+
+## Interwiki
+wfLoadExtension( 'Interwiki' );
 
 ## Thanks
 wfLoadExtension('Thanks');


### PR DESCRIPTION
Interwiki는 미디어위키에 번들되어 있기 때문에 LocalSettings.php만 수정하여 활성화할 수 있습니다.