### PR TITLE
사용자 권한 정리

### DIFF
--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -152,8 +152,8 @@ $wgExtraNamespaces[NS_BBSINTRO_TALK] = "가입인사게시판토론";
 $wgGroupPermissions['*']['createaccount'] = true;
 $wgGroupPermissions['bureaucrat']['usermerge'] = true;
 $wgGroupPermissions['bureaucrat']['renameuser'] = true;
-$wgGroupPermissions['sysop']['deletelogentry'] = true;
-$wgGroupPermissions['sysop']['deleterevision'] = true;
+$wgGroupPermissions['oversight']['deletelogentry'] = true;
+$wgGroupPermissions['oversight']['deleterevision'] = true;
 $wgGroupPermissions['sysop']['interwiki'] = true;
 
 ## Prevent anonymous users from edit pages
@@ -173,20 +173,19 @@ $wgAutopromote = [
 ## Allow autoconfirmed users to edit pages
 $wgGroupPermissions['user']['edit'] = false;
 $wgGroupPermissions['autoconfirmed']['edit'] = true;
-$wgGroupPermissions['seeder']['edit'] = true;
-$wgGroupPermissions['bureaucrat']['edit'] = true;
 
 ## Add restricted-sysop group
 $wgGroupPermissions['restricted-sysop'] = $wgGroupPermissions['sysop'];
 $wgGroupPermissions['restricted-sysop']['apihighlimits'] = false;
-$wgGroupPermissions['restricted-sysop']['deletelogentry'] = false;
-$wgGroupPermissions['restricted-sysop']['deleterevision'] = false;
 $wgGroupPermissions['restricted-sysop']['editinterface'] = false;
 $wgGroupPermissions['restricted-sysop']['editusercss'] = false;
 $wgGroupPermissions['restricted-sysop']['edituserjs'] = false;
 $wgGroupPermissions['restricted-sysop']['managechangetags'] = false;
 $wgGroupPermissions['restricted-sysop']['move-rootuserpages'] = false;
 $wgGroupPermissions['restricted-sysop']['unblockself'] = false;
+
+## Remain commemorative Seeder group
+$wgAddGroups['seeder'] = ['*'];
 
 # Show numbers on headings
 $wgDefaultUserOptions['numberheadings'] = 1;

--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -186,7 +186,7 @@ $wgGroupPermissions['restricted-sysop']['move-rootuserpages'] = false;
 $wgGroupPermissions['restricted-sysop']['unblockself'] = false;
 
 ## Remain commemorative Seeder group
-$wgAddGroups['seeder'] = ['*'];
+$wgGroupPermissions['seeder']['read'] = true;
 
 # Show numbers on headings
 $wgDefaultUserOptions['numberheadings'] = 1;

--- a/www/LocalSettings.php
+++ b/www/LocalSettings.php
@@ -155,6 +155,7 @@ $wgGroupPermissions['bureaucrat']['renameuser'] = true;
 $wgGroupPermissions['oversight']['deletelogentry'] = true;
 $wgGroupPermissions['oversight']['deleterevision'] = true;
 $wgGroupPermissions['sysop']['interwiki'] = true;
+$wgGroupPermissions['bot']['patrolmarks'] = true;
 
 ## Prevent anonymous users from edit pages
 $wgGroupPermissions['*']['edit'] = false;


### PR DESCRIPTION
- 웬만하면 중복으로 주어지는 edit 권한은 좀 더 높은 그룹에서 제했습니다. (예를 들어 bureaucrat은 거의 항상* auto-confirm이 되어 있을 테니 edit 권한을 따로 줄 이유가 없습니다)
- oversight(기록보호자)와 관련 있지만 sysop에게 주어졌던 deletelogentry, deleterevision 권한을 oversight에게 옮겼습니다.
- Seeder의 edit 권한을 없애고 Seeder가 존재만 하도록 했습니다. (위와 마찬가지로 Seeder는 거의 항상* auto-confirm 되어 있습니다) #185 

*거의 항상이라고 표현한 것은 편집 필터 등에 의해 자동 인증이 해제될 수 있기 때문입니다.