### PR TITLE
RESTBase 장소 이동 및 카산드라 사용

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -9,3 +9,8 @@ rewrite /w {
   r  /(.*)
   to /index.php
 }
+
+# Proxy requests to RESTBase
+# Reference:
+#   https://www.mediawiki.org/wiki/RESTBase/Installation#Proxy_requests_to_RESTBase_from_your_webserver
+proxy /femiwiki.com restbase:7231

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -287,7 +287,10 @@ $wgVirtualRestConfig['modules']['parsoid'] = [
 ];
 
 # Restbase server Setting
-$wgVirtualRestConfig['modules']['restbase']['domain'] = 'femiwiki.com';
+$wgVirtualRestConfig['modules']['restbase'] = [
+	'url' => 'http://restbase:7231',
+	'domain' => 'femiwiki.com'
+];
 $wgVisualEditorRestbaseURL = 'https://femiwiki.com/femiwiki.com/v1/page/html/';
 $wgVisualEditorFullRestbaseURL = 'https://femiwiki.com/femiwiki.com/';
 
@@ -538,8 +541,8 @@ if ( defined( 'DEBUG_MODE' ) ) {
 	$wgServer = 'http://' . DEBUG_MODE;
 	$wgCanonicalServer = 'http://' . DEBUG_MODE;
 	$wgVirtualRestConfig['modules']['restbase']['url'] = 'http://restbase:7231';
-	$wgVisualEditorRestbaseURL = 'http://' . DEBUG_MODE . ':7231/femiwiki.com/v1/page/html/';
-	$wgVisualEditorFullRestbaseURL = 'http://' . DEBUG_MODE . ':7231/femiwiki.com/';
+	$wgVisualEditorRestbaseURL = 'http://' . DEBUG_MODE . '/femiwiki.com/v1/page/html/';
+	$wgVisualEditorFullRestbaseURL = 'http://' . DEBUG_MODE . '/femiwiki.com/';
 
 	# 디버그 툴 활성화
 	$wgShowExceptionDetails = true;

--- a/configs/secret.php.example
+++ b/configs/secret.php.example
@@ -12,8 +12,10 @@ $wgDBserver = 'DB_HOSTNAME';
 $wgDBuser = 'DB_USERNAME';
 $wgDBpassword = 'DB_PASSWORD';
 
-# RESTBase address
-$wgVirtualRestConfig['modules']['restbase']['url'] = 'http://RESTBASE_HOSTNAME:7231';
+# RESTBase settings
+$wgRESTBaseCassandraServer = 'RESTBASE_DB_HOSTNAME';
+$wgRESTBaseCassandraUser = 'RESTBASE_DB_USERNAME';
+$wgRESTBaseCassandraPassword = 'RESTBASE_DB_PASSWORD';
 
 # Cache address
 $wgMemCachedServers = [ 'MEMCACHED_HOSTNAME:11211' ];

--- a/configs/secret.php.example
+++ b/configs/secret.php.example
@@ -13,9 +13,9 @@ $wgDBuser = 'DB_USERNAME';
 $wgDBpassword = 'DB_PASSWORD';
 
 # RESTBase settings
-$wgRESTBaseCassandraServer = 'RESTBASE_DB_HOSTNAME';
-$wgRESTBaseCassandraUser = 'RESTBASE_DB_USERNAME';
-$wgRESTBaseCassandraPassword = 'RESTBASE_DB_PASSWORD';
+$wgRESTBaseCassandraServer = 'CASSANDRA_HOSTNAME';
+$wgRESTBaseCassandraUser = 'CASSANDRA_USERNAME';
+$wgRESTBaseCassandraPassword = 'CASSANDRA_PASSWORD';
 
 # Cache address
 $wgMemCachedServers = [ 'MEMCACHED_HOSTNAME:11211' ];

--- a/development.yml
+++ b/development.yml
@@ -18,15 +18,15 @@ services:
   parsoid:
     image: femiwiki/parsoid:build-0
   restbase:
-    image: femiwiki/restbase:build-0
-    environment:
-      - MEDIAWIKI_APIS_URI=http://http/api.php
+    image: femiwiki/restbase:build-1
     ports:
       - 7231:7231
+    volumes:
+      - ./configs:/a:ro
     networks:
       default:
         aliases:
-          - RESTBASE_HOSTNAME
+          - RESTBASE_HOSTNAME # secret.php.example에 적힌 기본값
   mysql:
     image: mysql:8
     command: --default-authentication-plugin=mysql_native_password
@@ -35,19 +35,31 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=localfemiwikipassword
       - MYSQL_DATABASE=femiwiki
-      - MYSQL_USER=DB_USERNAME
-      - MYSQL_PASSWORD=DB_PASSWORD
+      - MYSQL_USER=DB_USERNAME # secret.php.example에 적힌 기본값
+      - MYSQL_PASSWORD=DB_PASSWORD # secret.php.example에 적힌 기본값
     networks:
       default:
         aliases:
-          - DB_HOSTNAME
+          - DB_HOSTNAME # secret.php.example에 적힌 기본값
+  cassandra:
+    image: femiwiki/cassandra:build-0
+    volumes:
+      - cassandra:/var/lib/cassandra
+    environment:
+      - USER_NAME=RESTBASE_DB_USERNAME # secret.php.example에 적힌 기본값
+      - DEV_PASSWORD=RESTBASE_DB_PASSWORD # secret.php.example에 적힌 기본값
+    networks:
+      default:
+        aliases:
+          - RESTBASE_DB_HOSTNAME # secret.php.example에 적힌 기본값
   memcached:
     image: memcached:1-alpine
     networks:
       default:
         aliases:
-          - MEMCACHED_HOSTNAME
+          - MEMCACHED_HOSTNAME # secret.php.example에 적힌 기본값
 
 volumes:
   files:
   database:
+  cassandra:

--- a/development.yml
+++ b/development.yml
@@ -46,12 +46,12 @@ services:
     volumes:
       - cassandra:/var/lib/cassandra
     environment:
-      - USER_NAME=RESTBASE_DB_USERNAME # secret.php.example에 적힌 기본값
-      - DEV_PASSWORD=RESTBASE_DB_PASSWORD # secret.php.example에 적힌 기본값
+      - USER_NAME=CASSANDRA_USERNAME # secret.php.example에 적힌 기본값
+      - DEV_PASSWORD=CASSANDRA_PASSWORD # secret.php.example에 적힌 기본값
     networks:
       default:
         aliases:
-          - RESTBASE_DB_HOSTNAME # secret.php.example에 적힌 기본값
+          - CASSANDRA_HOSTNAME # secret.php.example에 적힌 기본값
   memcached:
     image: memcached:1-alpine
     networks:

--- a/production.yml
+++ b/production.yml
@@ -14,5 +14,9 @@ services:
       - files:/srv/femiwiki.com
   parsoid:
     image: femiwiki/parsoid:build-0
+  restbase:
+    image: femiwiki/restbase:build-1
+    volumes:
+      - ./configs:/a:ro
 volumes:
   files:


### PR DESCRIPTION
- RESTBase가 데이터베이스 서버에서 미디어위키 서버로 옮겨갈 수 있도록 도커 컴포즈 파일 수정
- RESTBase 컨테이너를 위한 프록시를 캐디 설정에 추가
- RESTBase 관련 설정을 미디어위키에 추가

#### 관련 이슈

- https://github.com/femiwiki/femiwiki/issues/52