### PR TITLE
 LocalisationUpdate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,8 @@ RUN crontab /tmp/crontab && rm /tmp/crontab
 RUN sudo -u www-data mkdir -p /srv/femiwiki.com/sitemap
 COPY cron/generate-sitemap /usr/local/bin/generate-sitemap
 
+# Install 'localisation-update' script
+COPY cron/localisation-update /usr/local/bin/localisation-update
 
 # Store femiwiki resources
 COPY --chown=www-data:www-data resources /srv/femiwiki.com/

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -498,6 +498,9 @@ wfLoadExtension( 'OpenGraphMeta' );
 # PageImages
 wfLoadExtension( 'PageImages' );
 
+# LocalisationUpdate
+wfLoadExtension( 'LocalisationUpdate' );
+
 # FacetedCategory
 wfLoadExtension( 'FacetedCategory' );
 

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,1 +1,2 @@
 0 1,5,9,13,17,21 * * * /usr/local/bin/generate-sitemap
+0 5 * * * /usr/local/bin/localisation-update

--- a/cron/localisation-update
+++ b/cron/localisation-update
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# 주기적으로 실행해야하는 스크립트. 미디어위키의 시스템 메시지를 항상 최신으로
+# 유지시켜 준다.
+#
+# Reference:
+#   https://www.mediawiki.org/wiki/Extension:LocalisationUpdate
+
+set -euo pipefail; IFS=$'\n\t'
+
+cd /srv/femiwiki.com/extensions/LocalisationUpdate
+
+sudo -u www-data php update.php --quiet

--- a/extension-installer/install_extensions.rb
+++ b/extension-installer/install_extensions.rb
@@ -47,6 +47,7 @@ extensions_official = [
   'BetaFeatures',
   'VisualEditor',
   'Widgets',
+  'LocalisationUpdate',
 ]
 # 3rd party extensions and their URLs
 extensions_3rdparty = {

--- a/run
+++ b/run
@@ -28,6 +28,8 @@ fi
 
 # Run update script
 /srv/femiwiki.com/maintenance/update.php --quick
+# Update localisations for MediaWiki messages in the background
+php /srv/femiwiki.com/extensions/LocalisationUpdate/update.php &
 
 # Start cron daemon
 cron


### PR DESCRIPTION
Issue: https://github.com/femiwiki/mediawiki/issues/216

- Extension:LocalisationUpdate 확장기능 설치
- 콘테이너 시작 직후에 L10n 업데이트 실행
- 매일 오전 5시에 L10n 업데이트 실행

테스트하려고 REL1_32와 같이 해서 실행했더니 오랜 시간에 걸쳐 모든 확장기능의 L10n들을 확인하곤 `Found no new translations`을 뱉으며 그냥 끝나버려서 작동이 제대로 되는 건지 아닌지 확인이 안 됩니다. 그래서 Draft로 남깁니다.