### PR TITLE
github actions: Create a pull request instead of direct commit to master

### DIFF
--- a/.github/workflows/bump_extension.yml
+++ b/.github/workflows/bump_extension.yml
@@ -10,11 +10,14 @@ jobs:
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.6'
-    - run: |
-        ruby .github/bump_extension.rb '${{github.event.client_payload.extension}}' '${{github.event.client_payload.version}}'
-        git config --global user.email "admin@femiwiki.com"
-        git config --global user.name "femiwiki-bot"
-        git add .
-        git commit -m "Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}" \
-          -m "Triggerd on ${{github.event.client_payload.commits_url}}"
-        git push
+    - name: Update extensions.json
+      run: ruby .github/bump_extension.rb '${{github.event.client_payload.extension}}' '${{github.event.client_payload.version}}'
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: |
+          Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}
+          Triggerd on ${{github.event.client_payload.commits_url}}
+        title: Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}
+        branch: bump-${{github.event.client_payload.extension}}


### PR DESCRIPTION
| ![image](https://user-images.githubusercontent.com/28209361/75623594-d4472d80-5bee-11ea-9b94-3a8dd94c446f.png)<br/>https://github.com/lens0021/docker-mediawiki/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+Bump+to |
|--|
| ![image](https://user-images.githubusercontent.com/28209361/75623609-0c4e7080-5bef-11ea-87af-b5b656f5e922.png)<br/>https://github.com/lens0021/docker-mediawiki/pull/3 |

`bump-extension` dispatch 이벤트가 발생했을 때 (바로 master를 수정하는 것이 아니라) PR을 생성합니다.
구현 중 제안된 내용과는 다음과 같은 차이가 발생하였습니다.

- 여러 번 디스패치가 발생했을 경우 여러 확장기능에서 차이가 일어났다면 각각 브랜치를 생성하고 PR도 따로 생성합니다.
- 같은 확장기능에서 여러번 디스패치했을 경우 브랜치가 force-pushed 되고 PR도 고쳐집니다.

closes https://github.com/femiwiki/femiwiki/issues/157