### PR TITLE
github actions: Create a pull request instead of direct commit to master

### DIFF
--- a/.github/workflows/bump_extension.yml
+++ b/.github/workflows/bump_extension.yml
@@ -18,8 +18,6 @@ jobs:
       uses: peter-evans/create-pull-request@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: |
-          Bump ${{github.event.client_payload.extension}} to ${{steps.version.outputs.version}}
-          Triggerd on ${{github.event.client_payload.commits_url}}
+        commit-message: Bump ${{github.event.client_payload.extension}} to ${{steps.version.outputs.version}}
         title: Bump ${{github.event.client_payload.extension}} to ${{steps.version.outputs.version}}
         branch: bump-${{github.event.client_payload.extension}}

--- a/.github/workflows/bump_extension.yml
+++ b/.github/workflows/bump_extension.yml
@@ -7,17 +7,19 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - run: echo "::set-output name=version::$(echo ${{github.event.client_payload.version}} | cut -c1-7)"
+      id: version
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.6'
     - name: Update extensions.json
-      run: ruby .github/bump_extension.rb '${{github.event.client_payload.extension}}' '${{github.event.client_payload.version}}'
+      run: ruby .github/bump_extension.rb '${{github.event.client_payload.extension}}' '${{steps.version.outputs.version}}'
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: |
-          Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}
+          Bump ${{github.event.client_payload.extension}} to ${{steps.version.outputs.version}}
           Triggerd on ${{github.event.client_payload.commits_url}}
-        title: Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}
+        title: Bump ${{github.event.client_payload.extension}} to ${{steps.version.outputs.version}}
         branch: bump-${{github.event.client_payload.extension}}

--- a/.github/workflows/bump_extension.yml
+++ b/.github/workflows/bump_extension.yml
@@ -10,11 +10,14 @@ jobs:
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.6'
-    - run: |
-        ruby .github/bump_extension.rb '${{github.event.client_payload.extension}}' '${{github.event.client_payload.version}}'
-        git config --global user.email "admin@femiwiki.com"
-        git config --global user.name "femiwiki-bot"
-        git add .
-        git commit -m "Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}" \
-          -m "Triggerd on ${{github.event.client_payload.commits_url}}"
-        git push
+    - name: Update extensions.json
+      run: ruby .github/bump_extension.rb '${{github.event.client_payload.extension}}' '${{github.event.client_payload.version}}'
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: |
+          Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}
+          Triggerd on ${{github.event.client_payload.commits_url}}
+        title: Bump ${{github.event.client_payload.extension}} to ${{github.event.client_payload.version}}
+        branch: bump-${{github.event.client_payload.extension}}


### PR DESCRIPTION
[https://github.com/femiwiki/docker-mediawiki/pull/355](https://github.com/femiwiki/docker-mediawiki/pull/355)이 실수로 머지되어 돌리고 다시 열었습니다.

| ![image](https://user-images.githubusercontent.com/28209361/75625328-791e3680-5c00-11ea-8b9a-dae25ecd0433.png)<br/>https://github.com/lens0021/docker-mediawiki/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+Bump+to |
|--|

아래는 이전 PR의 본문입니다.

> `bump-extension` dispatch 이벤트가 발생했을 때 (바로 master를 수정하는 것이 아니라) PR을 생성합니다.
구현 중 제안된 내용과는 다음과 같은 차이가 발생하였습니다.
> 
> - 여러 번 디스패치가 발생했을 경우 여러 확장기능에서 차이가 일어났다면 각각 브랜치를 생성하고 PR도 따로 생성합니다.
> - 같은 확장기능에서 여러번 디스패치했을 경우 브랜치가 force-pushed 되고 PR도 고쳐집니다.
> 
> closes https://github.com/femiwiki/femiwiki/issues/157

아래는 이전 PR의 코멘트 일부와 답변입니다.

> 뜨아 글자수 제한 못거나요

별도 step 생성하여 7글자로 자르게 했습니다.

> commits_url을 요청 보내는사람이 쏘는거같은데 저거 필요한가용
> 요청 받는쪽에서 주소를 조립하면 어떨까용 저게 API 스펙이 되지는 않았으면 좋겠어서

주소 조립으로 하려고 확인해 보니 https://github.com/femiwiki/FemiwikiSkin/issues/123 문제로 페미위키 스킨은 조립이 불가합니다(받는 문자열은 `Femiwiki`지만 `https://github.com/femiwiki/FemiwikiSkin/commit/xxxxxxx`으로 링크하여야 하므로). 링크를 뺄까요?