### PR TITLE
github actions: Conditions tweaks

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -65,15 +65,13 @@ jobs:
           fi
         done; printf '\n'
     - name: Check if the container is still up
-      if: success()
-      run: test "$(docker service ps -qf 'desired-state=Running' mediawiki_fastcgi)"
+      run: test "$(docker service ps -qf 'desired-state=Running' -f 'desired-state=Ready' mediawiki_fastcgi)"
     - name: Try to access the mediawiki
-      if: success()
       run: curl -sSLvo /dev/null localhost || docker service logs mediawiki_fastcgi
 
     - name: Publish to Registry
       # Publish only when in the master branch
-      if: success() && (github.ref == 'refs/heads/master')
+      if: github.ref == 'refs/heads/master'
       uses: elgohr/Publish-Docker-Github-Action@2.12
       with:
         name: femiwiki/mediawiki


### PR DESCRIPTION
- https://github.com/femiwiki/docker-mediawiki/runs/479928907<br/>위 런이 실패하는 이유를 찾다가 `Ready` 상태인 것을 확인하여 같이 허용했습니다.
- `if: success()` 따로 적지 않아도 실패하면 뒤에 스텝은 알아서 정지되어서 뺐습니다