### PR TITLE
Get rid of Publish-Docker-Github-Action

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -41,12 +41,12 @@ jobs:
       id: tag
 
     - name: Build docker image using cache
-      env:
-        DOCKER_BUILDKIT: 1
+      # # BuildKit mode is compatible with UCP 3.2 or newer
+      # env:
+      #   DOCKER_BUILDKIT: 1
       run: |
         docker build \
           --cache-from femiwiki/mediawiki:latest \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
           --tag femiwiki/mediawiki:latest \
           --tag femiwiki/mediawiki:docker-test \
           --tag femiwiki/mediawiki:${{ steps.tag.outputs.tag }} \

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -37,11 +37,21 @@ jobs:
         printf 'const DEBUG_MODE = 'localhost';\nrequire_once "$IP/includes/DevelopmentSettings.php";\n' >> configs/LocalSettings.php;
         sed -i'' -r 's/femiwiki\/mediawiki:.+/femiwiki\/mediawiki:docker-test/' development.yml
 
-    - name: Pull docker image for cache
-      run: docker pull femiwiki/mediawiki 2>/dev/null
-    - name: Build docker image
+    - run: echo "::set-output name=tag::$(date +%Y%m%d%H%M%S)$(echo ${{ github.sha }} | cut -c1-6)"
+      id: tag
+
+    - name: Build docker image using cache
+      env:
+        DOCKER_BUILDKIT: 1
       run: |
-        docker build --tag femiwiki/mediawiki:docker-test --cache-from femiwiki/mediawiki .
+        docker build \
+          --cache-from femiwiki/mediawiki:latest \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          --tag femiwiki/mediawiki:latest \
+          --tag femiwiki/mediawiki:docker-test \
+          --tag femiwiki/mediawiki:${{ steps.tag.outputs.tag }} \
+          .
+
     - name: Initialize docker swarm and start services
       run: |
         docker swarm init
@@ -72,10 +82,9 @@ jobs:
     - name: Publish to Registry
       # Publish only when in the master branch
       if: github.ref == 'refs/heads/master'
-      uses: elgohr/Publish-Docker-Github-Action@2.12
-      with:
-        name: femiwiki/mediawiki
-        username: femiwikibot
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
-        buildargs: BUILDKIT_INLINE_CACHE=1
+      run: |
+        docker login -u femiwikibot --password-stdin ${{ secrets.DOCKER_PASSWORD }}
+        docker push \
+          femiwiki/mediawiki:latest \
+          femiwiki/mediawiki:${{ steps.tag.outputs.tag }}
+        docker logout


### PR DESCRIPTION
This PR removes Publish-Docker-Github-Action that does jobs are simple to implement directly.