### PR TITLE
LU: Print time as log

### DIFF
--- a/cron/localisation-update
+++ b/cron/localisation-update
@@ -9,10 +9,11 @@
 
 set -euo pipefail; IFS=$'\n\t'
 
+echo "Starting LU at $(date --iso-8601=minutes)"
 # Update l10n cache
 cd /srv/femiwiki.com/extensions/LocalisationUpdate
 
 sudo nice -n 19 php update.php
 sudo nice -n 19 php update.php --repoid femiwiki
 sudo nice -n 19 php update.php --repoid kulttuuri
-echo "All done"
+echo "All done at $(date --iso-8601=minutes)"

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -79,7 +79,7 @@
     "Femiwiki": {
       "type": "skin",
       "template": "https://github.com/femiwiki/FemiwikiSkin/archive/$1.tar.gz",
-      "version": "01e5debc"
+      "version": "7115b6df"
     },
     "LocalisationUpdate": {
       "@note": "See https://github.com/femiwiki/femiwiki/issues/114",


### PR DESCRIPTION
Print "Starting LU at 2020-03-11T11:29+09:00" and "All done at 2020-03-11T11:29+09:00" after or before every Localisation Updates.