### PR TITLE
Preload HSTS

### DIFF
--- a/caddy/Caddyfile.prod
+++ b/caddy/Caddyfile.prod
@@ -8,7 +8,7 @@ fastcgi / fastcgi:9000 php
 gzip
 header / {
   # HSTS
-  Strict-Transport-Security "max-age=15768000"
+  Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
   # Enable XSS filtering for legacy browsers
   X-XSS-Protection "1; mode=block"
   # Block content sniffing, and enable Cross-Origin Read Blocking


### PR DESCRIPTION
https://hstspreload.org/?domain=femiwiki.com 를 방문했을 때 나오는 다음 경고를 해소합니다.

- Error: No includeSubDomains directive<br/>The header must contain the `includeSubDomains` directive.
- Error: No preload directive<br/>The header must contain the `preload` directive.
- Error: Max-age too low<br/>The max-age must be at least 31536000 seconds (≈ 1 year), but the header currently only has max-age=15768000.

Caddyfile 문법을 잘 모르겠어서 Draft로 올립니다. 테스트가 필요한데 어디서 테스트할진 잘 모르겠습니다.

Related to https://github.com/femiwiki/femiwiki/issues/103