### PR TITLE
Fix invalid sitemap urls

### DIFF
--- a/cron/generate-sitemap
+++ b/cron/generate-sitemap
@@ -13,6 +13,6 @@ cd /srv/femiwiki.com
 sudo -u www-data php maintenance/generateSitemap.php \
   --fspath sitemap \
   --server 'https://femiwiki.com' \
-  --urlpath 'https://femiwiki.com/sitemap' \
+  --urlpath '/sitemap/' \
   --skip-redirects \
   --compress=no


### PR DESCRIPTION
> Before MediaWiki 1.32 this parameter should contain the protocol and host name. However, since MediaWiki 1.32 the contents of this parameter will be appended to the `--server`parameter, thus it doesn't have to contain protocol nor hostname.
--Manual:GenerateSitemap.php https://www.mediawiki.org/?oldid=3258361

> **This is a breaking change not announced via the RELEASE-NOTES.** -- https://www.mediawiki.org/?oldid=3258384

Related to https://github.com/femiwiki/femiwiki/issues/205