### PR TITLE
Bump MediaWiki to v1.35.0 and improve MW experiences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@
 #
 FROM ghcr.io/femiwiki/base-extensions:2020-09-05T09-47-cc87d07f
 
-ARG MEDIAWIKI_MAJOR_VERSION=1.34
-ARG MEDIAWIKI_BRANCH=REL1_34
-ARG MEDIAWIKI_VERSION=1.34.1
-ARG MEDIAWIKI_SHA512=58310c04cd86bfa670185123dd25ccdbac8d90bb17107026ae801640620571967ee83eedf4e91cfdda740d646707cb0a054ee9e8ce367f21768b62af4e251d02
+ARG MEDIAWIKI_MAJOR_VERSION=1.35
+ARG MEDIAWIKI_BRANCH=REL1_35
+ARG MEDIAWIKI_VERSION=1.35.0
 
 RUN mkdir -p /tmp/mediawiki/ &&\
     chown www-data:www-data /tmp/mediawiki/
@@ -20,7 +19,6 @@ RUN sudo -u www-data ruby /tmp/install_extensions.rb "${MEDIAWIKI_BRANCH}"
 # MediaWiki setup
 COPY --chown=www-data configs/composer.local.json /tmp/mediawiki/
 RUN curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-core-${MEDIAWIKI_VERSION}.tar.gz" -o mediawiki.tar.gz &&\
-    echo "${MEDIAWIKI_SHA512} *mediawiki.tar.gz" | sha512sum -c - &&\
     sudo -u www-data tar -xzf mediawiki.tar.gz --strip-components=1 --directory /tmp/mediawiki/ &&\
     rm mediawiki.tar.gz
 RUN sudo -u www-data COMPOSER_HOME=/tmp/composer composer update --no-dev --working-dir '/tmp/mediawiki'

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -808,7 +808,7 @@ wfLoadExtension( 'Thanks' );
 wfLoadExtension( 'TitleBlacklist' );
 
 // Translate
-include_once "$IP/extensions/Translate/Translate.php";
+wfLoadExtension( 'Translate' );
 $wgGroupPermissions['autoconfirmed']['translate'] = true;
 $wgGroupPermissions['translationadmin']['pagetranslation'] = true;
 $wgGroupPermissions['translationadmin']['translate-manage'] = true;

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -519,6 +519,10 @@ $wgDiscordSendMethod = 'file_get_contents';
 $wgWikiUrlEndingUserRights = "Special:UserRights/";
 $wgWikiUrlEndingBlockUser = '특수:제재안목록/';
 
+// DiscussionTools
+wfLoadExtension( 'DiscussionTools' );
+$wgDiscussionToolsEnableVisual = true;
+
 // Echo
 wfLoadExtension( 'Echo' );
 $wgEchoMaxMentionsInEditSummary = 5;

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -76,16 +76,6 @@ $wgLogos = [
 		'height' => 56
 	]
 ];
-if ( version_compare( MW_VERSION, '1.35', '<' ) ) {
-	global $wgLogos, $wgLogoHD, $wgFemiwikiLogos;
-	$wgLogoHD = [
-		// maximally 135x135
-		"1.5x" => $wgLogo,
-		// maximally 270x270
-		"2x" => "$wgResourceBasePath/fw-resources/logo-square-transparent-violet-240x200.png"
-	];
-	$wgFemiwikiLogos = $wgLogos;
-}
 
 // UPO means: this is also a user preference option
 //

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -325,7 +325,6 @@ $wgAllowUserJs = true;
 
 // Allow external image link
 $wgAllowExternalImages = true;
-$wgAllowImageTag = true;
 
 // all pages (that are not redirects) are considered as valid articles
 $wgArticleCountMethod = 'any';

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -35,15 +35,15 @@ $wgResourceBasePath = $wgScriptPath;
 $wgStyleVersion = '20191101_0';
 $wgResourceLoaderMaxage = [
 	'versioned' => [
-		# Squid/Varnish but also any other public proxy cache between the client and MediaWiki
-		'server' => 90 * 24 * 60 * 60, # 90 days
-		# On the client side (e.g. in the browser cache).
-		'client' => 90 * 24 * 60 * 60, # 90 days
+		// Squid/Varnish but also any other public proxy cache between the client and MediaWiki
+		'server' => 90 * 24 * 60 * 60, // 90 days
+		// On the client side (e.g. in the browser cache).
+		'client' => 90 * 24 * 60 * 60, // 90 days
 	],
 	'unversioned' => [
-		# 3 minutes
+		// 3 minutes
 		'server' => 3 * 60,
-		# 3 minutes
+		// 3 minutes
 		'client' => 3 * 60,
 	],
 ];
@@ -79,9 +79,9 @@ $wgLogos = [
 if ( version_compare( MW_VERSION, '1.35', '<' ) ) {
 	global $wgLogos, $wgLogoHD, $wgFemiwikiLogos;
 	$wgLogoHD = [
-		# maximally 135x135
+		// maximally 135x135
 		"1.5x" => $wgLogo,
-		# maximally 270x270
+		// maximally 270x270
 		"2x" => "$wgResourceBasePath/fw-resources/logo-square-transparent-violet-240x200.png"
 	];
 	$wgFemiwikiLogos = $wgLogos;
@@ -92,7 +92,7 @@ if ( version_compare( MW_VERSION, '1.35', '<' ) ) {
 // Reference:
 // - https://www.mediawiki.org/wiki/Help:User_preference_option
 $wgEnableEmail = true;
-$wgEnableUserEmail = true; # UPO
+$wgEnableUserEmail = true; // UPO
 $wgAllowHTMLEmail = true;
 $wgSMTP = [
 	'host' => 'email-smtp.us-east-1.amazonaws.com',
@@ -106,8 +106,8 @@ $wgEmergencyContact = 'admin@femiwiki.com';
 $wgPasswordSender = 'admin@femiwiki.com';
 $wgUserEmailUseReplyTo = true;
 
-$wgEnotifUserTalk = false; # UPO
-$wgEnotifWatchlist = false; # UPO
+$wgEnotifUserTalk = false; // UPO
+$wgEnotifWatchlist = false; // UPO
 $wgEmailAuthentication = true;
 $wgEmailConfirmToEdit = true;
 $wgEnableUserEmailBlacklist = true;
@@ -969,7 +969,7 @@ require_once '/a/secret.php';
 // Debug Mode
 //
 if ( defined( 'DEBUG_MODE' ) ) {
-	# 도메인 변경
+	// 도메인 변경
 	$wgServer = 'http://' . DEBUG_MODE;
 	$wgCanonicalServer = 'http://' . DEBUG_MODE;
 	$wgVirtualRestConfig['modules']['restbase']['url'] = 'http://restbase:7231';
@@ -981,22 +981,22 @@ if ( defined( 'DEBUG_MODE' ) ) {
 
 	$wgBounceHandlerInternalIPs = [ '0.0.0.0/0' ];
 
-	# 디버그 툴 활성화
+	// 디버그 툴 활성화
 	require_once "includes/DevelopmentSettings.php";
 	$wgDebugToolbar = true;
 	$wgShowDBErrorBacktrace = true;
 
-	# File Cache가 비활성화되어있어야 디버그 툴을 쓸 수 있음
+	// File Cache가 비활성화되어있어야 디버그 툴을 쓸 수 있음
 	$wgUseFileCache = false;
 
-	# 이메일 인증 요구 비활성화
+	// 이메일 인증 요구 비활성화
 	$wgEmailConfirmToEdit = false;
 
-	# AWS 플러그인 비활성화
+	// AWS 플러그인 비활성화
 	$wgAWSBucketName = null;
 	$wgAWSBucketPrefix = null;
 
-	# 구글 리캡차 비활성화
+	// 구글 리캡차 비활성화
 	$wgCaptchaTriggers['edit'] = false;
 	$wgCaptchaTriggers['create'] = false;
 	$wgCaptchaTriggers['createtalk'] = false;

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -826,7 +826,6 @@ $wgDefaultUserOptions['twocolconflict'] = '1';
 
 // UnifiedExtensionForFemiwiki
 wfLoadExtension( 'UnifiedExtensionForFemiwiki' );
-$wgSpecialPages['Uncategorizedcategories'] = 'SpecialUncategorizedCategoryTree';
 $wgSpecialPages['Whatlinkshere'] = 'SpecialOrderedWhatlinkshere';
 
 // UniversalLanguageSelector

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -29,6 +29,9 @@ $wgServer = 'https://femiwiki.com';
 $wgCanonicalServer = 'https://femiwiki.com';
 $wgEnableCanonicalServerLink = true;
 
+// Make the HTTP to HTTPS redirect be unconditional
+$wgForceHTTPS = true;
+
 // The URL path to static resources (images, scripts, etc.)
 $wgResourceBasePath = $wgScriptPath;
 
@@ -950,6 +953,7 @@ require_once '/a/secret.php';
 //
 if ( defined( 'DEBUG_MODE' ) ) {
 	// 도메인 변경
+	$wgForceHTTPS = false;
 	$wgServer = 'http://' . DEBUG_MODE;
 	$wgCanonicalServer = 'http://' . DEBUG_MODE;
 	$wgVirtualRestConfig['modules']['restbase']['url'] = 'http://restbase:7231';

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -34,36 +34,16 @@ $wgResourceBasePath = $wgScriptPath;
 
 $wgStyleVersion = '20191101_0';
 $wgResourceLoaderMaxage = [
-	'versioned' => [
-		// Squid/Varnish but also any other public proxy cache between the client and MediaWiki
-		'server' => 90 * 24 * 60 * 60, // 90 days
-		// On the client side (e.g. in the browser cache).
-		'client' => 90 * 24 * 60 * 60, // 90 days
-	],
-	'unversioned' => [
-		// 3 minutes
-		'server' => 3 * 60,
-		// 3 minutes
-		'client' => 3 * 60,
-	],
+	'versioned' => 90 * 24 * 60 * 60, // 90 days
+	'unversioned' => 3 * 60, // 3 minutes
 ];
 
 // The URL path to the logo.
-// References:
-// - https://www.mediawiki.org/wiki/Manual:$wgLogo
-// - https://www.mediawiki.org/wiki/Manual:$wgLogoHD
-// - https://www.mediawiki.org/wiki/Manual:$wgLogos
-// Note:
-// - $wgLogoHD is deprecated since MW 1.35
-// - $wgLogos is introduced in MW 1.35, therefore below declaration does not affect the core yet.
-
-// maximally 135x135
-$wgLogo = "$wgResourceBasePath/fw-resources/logo-square-transparent-violet-135x114.png";
 $wgLogos = [
 	// maximally 50x50
 	'icon' => "$wgResourceBasePath/fw-resources/icon-transparent-white-50x50.png",
 	// maximally 135x135
-	'1x' => $wgLogo,
+	'1x' => "$wgResourceBasePath/fw-resources/logo-square-transparent-violet-135x114.png",
 	// maximally 202x202
 	'1.5x' => "$wgResourceBasePath/fw-resources/logo-square-transparent-violet-202x170.png",
 	// maximally 270x270
@@ -77,13 +57,6 @@ $wgLogos = [
 	]
 ];
 
-// UPO means: this is also a user preference option
-//
-// Reference:
-// - https://www.mediawiki.org/wiki/Help:User_preference_option
-$wgEnableEmail = true;
-$wgEnableUserEmail = true; // UPO
-$wgAllowHTMLEmail = true;
 $wgSMTP = [
 	'host' => 'email-smtp.us-east-1.amazonaws.com',
 	'IDHost' => 'femiwiki.com',
@@ -92,9 +65,17 @@ $wgSMTP = [
 	'username' => 'AKIAJ472HG7XALTXZ5QA',
 ];
 
+// UPO means: this is also a user preference option
+//
+// Reference:
+// - https://www.mediawiki.org/wiki/Help:User_preference_option
+$wgEnableEmail = true;
+$wgEnableUserEmail = true; // UPO
+$wgAllowHTMLEmail = true;
+$wgUserEmailUseReplyTo = true;
+
 $wgEmergencyContact = 'admin@femiwiki.com';
 $wgPasswordSender = 'admin@femiwiki.com';
-$wgUserEmailUseReplyTo = true;
 
 $wgEnotifUserTalk = false; // UPO
 $wgEnotifWatchlist = false; // UPO
@@ -123,11 +104,11 @@ $wgPasswordPolicy['policies']['default']['MinimalPasswordLength'] = [
 ];
 
 // Shared memory settings
-$wgMemCachedServers = [ 'memcached:11211' ];
 $wgMainCacheType = CACHE_MEMCACHED;
 $wgSessionCacheType = CACHE_MEMCACHED;
 $wgParserCacheType = CACHE_MEMCACHED;
 $wgMessageCacheType = CACHE_MEMCACHED;
+$wgMemCachedServers = [ 'memcached:11211' ];
 
 // To enable image uploads, make sure the 'images' directory
 // is writable, then set this to true:
@@ -167,6 +148,14 @@ $wgPageLanguageUseDB = true;
 
 // Changing this will log out all existing sessions.
 $wgAuthenticationTokenVersion = '1';
+
+## For attaching licensing metadata to pages, and displaying an
+## appropriate copyright notice / icon. GNU Free Documentation
+## License and Creative Commons licenses are supported so far.
+$wgRightsPage = '페미위키:저작권';
+$wgRightsUrl = 'https://creativecommons.org/licenses/by-sa/4.0/deed.ko';
+$wgRightsText = '크리에이티브 커먼즈 저작자표시-동일조건변경허락 4.0 국제 라이선스';
+$wgRightsIcon = "$wgResourceBasePath/resources/assets/licenses/cc-by-sa.png";
 
 // Path to the GNU diff3 utility. Used for conflict resolution.
 $wgDiff3 = '/usr/bin/diff3';
@@ -325,16 +314,11 @@ $wgRestrictDisplayTitle = false;
 $wgExternalLinkTarget = '_blank';
 
 // The number of authors that credited below an article text.
+// https://github.com/femiwiki/FemiwikiSkin/issues/137
 $wgMaxCredits = 5;
 
 // Allow partial blocks to be created
 $wgEnablePartialBlocks = true;
-
-// Copyright
-$wgRightsPage = '페미위키:저작권';
-$wgRightsUrl = 'https://creativecommons.org/licenses/by-sa/4.0/deed.ko';
-$wgRightsText = '크리에이티브 커먼즈 저작자표시-동일조건변경허락 4.0 국제 라이선스';
-$wgRightsIcon = "$wgResourceBasePath/resources/assets/licenses/cc-by-sa.png";
 
 // User CSS and JS
 $wgAllowUserCss = true;
@@ -532,7 +516,7 @@ wfLoadExtension( 'EventStreamConfig' );
 wfLoadExtension( 'FacetedCategory' );
 
 // FlaggedRevs
-require_once "$IP/extensions/FlaggedRevs/FlaggedRevs.php";
+wfLoadExtension( 'FlaggedRevs' );
 $wgFlaggedRevsNamespaces = [
 	NS_MAIN,
 	NS_PROJECT,

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -122,7 +122,6 @@ $wgFileExtensions = array_merge(
 		'svg',
 	]
 );
-$wgAllowTitlesInSVG = true;
 $wgUseImageMagick = true;
 $wgImageMagickConvertCommand = '/usr/bin/convert';
 $wgSVGConverter = 'rsvg';
@@ -319,9 +318,6 @@ $wgExternalLinkTarget = '_blank';
 // The number of authors that credited below an article text.
 // https://github.com/femiwiki/FemiwikiSkin/issues/137
 $wgMaxCredits = 5;
-
-// Allow partial blocks to be created
-$wgEnablePartialBlocks = true;
 
 // User CSS and JS
 $wgAllowUserCss = true;

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -596,6 +596,9 @@ wfLoadExtension( 'Interwiki' );
 // Josa
 wfLoadExtension( 'Josa' );
 
+// Linter
+wfLoadExtension( 'Linter' );
+
 // LocalisationUpdate
 wfLoadExtension( 'LocalisationUpdate' );
 $wgLocalisationUpdateRepositories = [

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -395,6 +395,7 @@ $wgVirtualRestConfig['modules']['restbase'] = [
 ];
 $wgVisualEditorRestbaseURL = 'https://femiwiki.com/femiwiki.com/v1/page/html/';
 $wgVisualEditorFullRestbaseURL = 'https://femiwiki.com/femiwiki.com/';
+$wgMathFullRestbaseURL = 'https://femiwiki.com/femiwiki.com/';
 
 //
 // Extensions
@@ -619,6 +620,11 @@ $wgLocalisationUpdateHttpRequestOptions = [
 
 // LoginNotify
 wfLoadExtension( 'LoginNotify' );
+
+// Math
+wfLoadExtension( 'Math' );
+$wgDefaultUserOptions['math'] = 'mathml';
+$wgMathMathMLUrl = 'http://mathoid:10044/'; // IP of Mathoid server
 
 // MobileFrontend
 wfLoadExtension( 'MobileFrontend' );
@@ -953,6 +959,7 @@ if ( defined( 'DEBUG_MODE' ) ) {
 	$wgVirtualRestConfig['modules']['restbase']['url'] = 'http://restbase:7231';
 	$wgVisualEditorRestbaseURL = 'http://' . DEBUG_MODE . '/femiwiki.com/v1/page/html/';
 	$wgVisualEditorFullRestbaseURL = 'http://' . DEBUG_MODE . '/femiwiki.com/';
+	$wgMathFullRestbaseURL = 'http://' . DEBUG_MODE . '/femiwiki.com/';
 	$wgWBRepoSettings['conceptBaseUri'] = $wgServer . '/w/Item:';
 	$wgWBClientSettings['dataBridgeHrefRegExp'] = '^' . $wgCanonicalServer .
 		str_replace( '$1', 'Item:(Q[1-9][0-9]*).*#(P[1-9][0-9]*)', $wgArticlePath ) . '$';

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -748,9 +748,6 @@ $wgScribuntoDefaultEngine = 'luastandalone';
 // SecureLinkFixer
 wfLoadExtension( 'SecureLinkFixer' );
 
-// SimpleMathJax
-wfLoadExtension( 'SimpleMathJax' );
-
 // SpamBlacklist
 wfLoadExtension( 'SpamBlacklist' );
 // Empty Meta-Wiki blacklist

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -623,7 +623,6 @@ wfLoadExtension( 'LoginNotify' );
 
 // MobileFrontend
 wfLoadExtension( 'MobileFrontend' );
-$wgMFDefaultSkinClass = 'SkinFemiwiki';
 $wgMFMwApiContentProviderBaseUri = $wgCanonicalServer . '/api.php';
 $wgMFMcsContentProviderBaseUri = $wgCanonicalServer . '/femiwiki.com/v1';
 // Disable automatically showing mobile view, as FemiwikiSkin is little responsive and

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -525,6 +525,9 @@ wfLoadExtension( 'EventLogging' );
 $wgEventLoggingBaseUri = 'http://localhost:8080/event.gif';
 $wgEventLoggingFile = '/var/log/mediawiki/events.log';
 
+// EventStreamConfig
+wfLoadExtension( 'EventStreamConfig' );
+
 // FacetedCategory
 wfLoadExtension( 'FacetedCategory' );
 

--- a/development.yml
+++ b/development.yml
@@ -31,7 +31,7 @@ services:
     environment:
       - MEDIAWIKI_LINTING=true
   mysql:
-    image: mysql:8.0.17
+    image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - database:/var/lib/mysql

--- a/development.yml
+++ b/development.yml
@@ -56,6 +56,8 @@ services:
       default:
         aliases:
           - RESTBASE_HOSTNAME # secret.php.example에 적힌 기본값
+  mathoid:
+    image: wikimedia/mathoid:bad5ec8d4
 
 volumes:
   files:

--- a/development.yml
+++ b/development.yml
@@ -28,6 +28,8 @@ services:
       # - ../UnifiedExtensionForFemiwiki:/srv/femiwiki.com/extensions/UnifiedExtensionForFemiwiki
   parsoid:
     image: ghcr.io/femiwiki/parsoid:2020-09-05T10-03-ae442600
+    environment:
+      - MEDIAWIKI_LINTING=true
   mysql:
     image: mysql:8.0.17
     command: --default-authentication-plugin=mysql_native_password

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -68,24 +68,24 @@
   "non-WMF": {
     "CategoryIntersectionSearch": {
       "template": "https://github.com/femiwiki/CategoryIntersectionSearch/releases/download/$1/$1.tar.gz",
-      "version": "v0.0.3"
+      "version": "v1.0.0"
     },
     "FacetedCategory": {
       "template": "https://github.com/femiwiki/FacetedCategory/releases/download/$1/$1.tar.gz",
-      "version": "v0.0.5"
+      "version": "v1.0.0"
     },
     "Sanctions": {
       "template": "https://github.com/femiwiki/Sanctions/releases/download/$1/$1.tar.gz",
-      "version": "v1.0.5"
+      "version": "v1.1.1"
     },
     "UnifiedExtensionForFemiwiki": {
       "template": "https://github.com/femiwiki/UnifiedExtensionForFemiwiki/releases/download/$1/$1.tar.gz",
-      "version": "v0.1.0"
+      "version": "v1.0.0"
     },
     "Femiwiki": {
       "type": "skin",
       "template": "https://github.com/femiwiki/FemiwikiSkin/releases/download/$1/$1.tar.gz",
-      "version": "v1.2.2"
+      "version": "v1.3.0"
     },
     "LocalisationUpdate": {
       "@note": "See https://github.com/femiwiki/femiwiki/issues/114",

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -19,6 +19,7 @@
     "DiscussionTools",
     "Echo",
     "EventLogging",
+    "EventStreamConfig",
     "FlaggedRevs",
     "Flow",
     "Gadgets",

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -100,9 +100,6 @@
     },
     "EmbedVideo": {
       "template": "https://gitlab.com/hydrawiki/extensions/EmbedVideo/-/archive/3c2a3e8/EmbedVideo-3c2a3e8.tar.gz"
-    },
-    "SimpleMathJax": {
-      "template": "https://github.com/jmnote/SimpleMathJax/archive/v0.7.4.tar.gz"
     }
   }
 }

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -28,6 +28,7 @@
     "InputBox",
     "Interwiki",
     "Josa",
+    "LocalisationUpdate",
     "LoginNotify",
     "MobileFrontend",
     "Newsletter",
@@ -58,6 +59,7 @@
     "UniversalLanguageSelector",
     "UploadWizard",
     "UserMerge",
+    "VisualEditor",
     "Widgets",
     "Wikibase",
     "WikiEditor"
@@ -86,14 +88,6 @@
       "type": "skin",
       "template": "https://github.com/femiwiki/FemiwikiSkin/releases/download/$1/$1.tar.gz",
       "version": "v1.3.0"
-    },
-    "LocalisationUpdate": {
-      "@note": "See https://github.com/femiwiki/femiwiki/issues/114",
-      "template": "https://github.com/femiwiki/mediawiki-extensions-LocalisationUpdate/archive/REL1_34.tar.gz"
-    },
-    "VisualEditor": {
-      "@note": "See https://github.com/femiwiki/femiwiki/issues/152",
-      "template": "https://github.com/femiwiki/mediawiki-extensions-VisualEditor/releases/download/REL1_34/REL1_34.tar.gz"
     },
     "AWS": {
       "template": "https://github.com/edwardspec/mediawiki-aws-s3/archive/v0.11.0.tar.gz"

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -29,6 +29,7 @@
     "InputBox",
     "Interwiki",
     "Josa",
+    "Linter",
     "LocalisationUpdate",
     "LoginNotify",
     "MobileFrontend",

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -16,6 +16,7 @@
     "Description2",
     "DisableAccount",
     "Disambiguator",
+    "DiscussionTools",
     "Echo",
     "EventLogging",
     "FlaggedRevs",

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -32,6 +32,7 @@
     "Linter",
     "LocalisationUpdate",
     "LoginNotify",
+    "Math",
     "MobileFrontend",
     "Newsletter",
     "Nuke",

--- a/production.yml
+++ b/production.yml
@@ -34,6 +34,8 @@ services:
       - MEDIAWIKI_APIS_URI=https://femiwiki.com/api.php
     volumes:
       - /srv/restbase.sqlite3:/srv/restbase/db.sqlite3
+  mathoid:
+    image: wikimedia/mathoid:bad5ec8d4
   mysql:
     image: mysql:8.0.17
     ports:

--- a/production.yml
+++ b/production.yml
@@ -25,6 +25,8 @@ services:
       - l18n_cache:/tmp/cache
   parsoid:
     image: ghcr.io/femiwiki/parsoid:2020-09-05T10-03-ae442600
+    environment:
+      - MEDIAWIKI_LINTING=true
   restbase:
     image: ghcr.io/femiwiki/restbase:2020-09-05T10-04-5dcdc8b6
     environment:

--- a/production.yml
+++ b/production.yml
@@ -37,7 +37,7 @@ services:
   mathoid:
     image: wikimedia/mathoid:bad5ec8d4
   mysql:
-    image: mysql:8.0.17
+    image: mysql:8.0.21
     ports:
       - 3306:3306
     command: --default-authentication-plugin=mysql_native_password
@@ -47,7 +47,7 @@ services:
     environment:
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
   memcached:
-    image: memcached:1.5.17-alpine
+    image: memcached:1.6.6-alpine
 
 volumes:
   files:


### PR DESCRIPTION
- Bump MediaWiki to v1.35.0 (https://github.com/femiwiki/femiwiki/issues/141)
- Install extensions
  - DiscussionTools (Closes https://github.com/femiwiki/femiwiki/issues/196)
  - Linter (Closes https://github.com/femiwiki/docker-mediawiki/issues/248)
  - Math (Closes https://github.com/femiwiki/docker-mediawiki/issues/287)
  - EventStreamConfig
- Bump Femiwiki extensions
- Uninstall SimpleMathJax
- Deploy Mathoid
- Remove MW v1.34 workarounds
  - LocalisationUpdate https://github.com/femiwiki/femiwiki/issues/114
  - VisualEditor https://github.com/femiwiki/femiwiki/issues/152
- Configuration changes:
  - Added [`$wgForceHTTPS = true;`](https://www.mediawiki.org/wiki/Manual:$wgForceHTTPS)
  - Remove deprecated confs:
    - `$wgAllowTitlesInSVG`
    - `$wgEnablePartialBlocks`
    - `$wgAllowImageTag`
    - `$wgLogo`