### PR TITLE
Merge web server(Caddy v2) into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,6 +179,9 @@ VOLUME /a
 
 WORKDIR /srv/femiwiki.com
 
+# Copy Caddyfile for web server usage. See README.md for detail.
+COPY caddy/Caddyfile.prod /srv/femiwiki.com/Caddyfile
+
 EXPOSE 80
 EXPOSE 443
 EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,14 @@ RUN curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSIO
 RUN sudo -u www-data COMPOSER_HOME=/tmp/composer composer update --no-dev --working-dir '/tmp/mediawiki'
 
 #
+# Caddy에 Route53 패키지를 설치한다.
+#
+FROM caddy:2.2.0-builder AS caddy
+
+RUN xcaddy build \
+      --with github.com/caddy-dns/route53
+
+#
 # 미디어위키 도커이미지 생성 스테이지. 미디어위키 실행에 필요한 각종 PHP
 # 디펜던시들을 설치한다.
 #
@@ -71,6 +79,7 @@ RUN sudo -u www-data COMPOSER_HOME=/tmp/composer composer update --no-dev --work
 #   /srv/femiwiki.com      미디어위키 소스코드 및 확장들
 #   /usr/local/{bin,sbin}  임의로 설치한 실행파일들
 #   /tmp/cache             캐시 디렉토리
+#   /tmp/log/cron          크론 로그
 #   /tini                  tini
 #
 FROM php:7.3.22-fpm
@@ -88,6 +97,19 @@ RUN apt-get update && apt-get install -y \
       # CLI utilities
       cron \
       sudo
+
+# Install Caddy
+COPY --from=caddy /usr/bin/caddy /usr/bin/caddy
+
+RUN mkdir -p \
+      /config/caddy \
+      /data/caddy \
+      /etc/caddy \
+      /usr/share/caddy
+
+# See https://caddyserver.com/docs/conventions#file-locations for details
+ENV XDG_CONFIG_HOME /config
+ENV XDG_DATA_HOME /data
 
 # Install the PHP extensions we need
 RUN docker-php-ext-install -j8 mysqli opcache intl
@@ -156,6 +178,9 @@ COPY --chown=www-data:www-data resources /srv/femiwiki.com/
 VOLUME /a
 
 WORKDIR /srv/femiwiki.com
+
+EXPOSE 80
+EXPOSE 443
 EXPOSE 9000
 
 COPY run /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ sudo docker stack deploy --prune -c ~/mediawiki/production.yml mediawiki
 sudo docker stack deploy --prune -c ~/mediawiki/bots.yml bots
 ```
 
+### About Docker image
+
+페미위키를 위한 [PHP-FPM] 서버입니다.
+동일한 이미지를 `caddy run` 커맨드로 사용할 경우에는 웹 서버를 실행할 수 있습니다.
+다음 예시 Compose file를 참고해 주세요.
+
+```yml
+http:
+  image: ghcr.io/femiwiki/mediawiki
+  command: caddy run
+  ports:
+    - 80:80
+  volumes:
+    - ./caddy/Caddyfile.dev:/srv/femiwiki.com/Caddyfile:ro
+      window: 120s
+fastcgi:
+  image: ghcr.io/femiwiki/mediawiki
+  volumes:
+    - ./configs:/a:ro
+```
+
 &nbsp;
 
 --------
@@ -58,5 +79,6 @@ of the [GNU Affero General Public License v3.0] or any later version. See
 [Docker Swarm]: https://docs.docker.com/engine/swarm/
 [femiwiki/ami]: https://github.com/femiwiki/ami
 [secret.php]: configs/secret.php.example
+[php-fpm]: https://php-fpm.org/
 [GNU Affero General Public License v3.0]: LICENSE
 [COPYRIGHT]: COPYRIGHT

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ sudo docker stack deploy --prune -c ~/mediawiki/bots.yml bots
 ### About Docker image
 
 페미위키를 위한 [PHP-FPM] 서버입니다.
-동일한 이미지를 `caddy run` 커맨드로 사용할 경우에는 웹 서버를 실행할 수 있습니다.
+동일한 이미지를 `caddy run` 커맨드로 사용할 경우에는 [Caddy] 웹 서버를 실행할 수 있습니다.
+개발 등의 목적으로 Caddyfile을 변경해야 할 경우에는 `/srv/femiwiki.com/Caddyfile`을 교체할 수 있습니다.
 다음 예시 Compose file를 참고해 주세요.
 
 ```yml
@@ -56,7 +57,6 @@ http:
     - 80:80
   volumes:
     - ./caddy/Caddyfile.dev:/srv/femiwiki.com/Caddyfile:ro
-      window: 120s
 fastcgi:
   image: ghcr.io/femiwiki/mediawiki
   volumes:
@@ -80,5 +80,6 @@ of the [GNU Affero General Public License v3.0] or any later version. See
 [femiwiki/ami]: https://github.com/femiwiki/ami
 [secret.php]: configs/secret.php.example
 [php-fpm]: https://php-fpm.org/
+[Caddy]: https://caddyserver.com/
 [GNU Affero General Public License v3.0]: LICENSE
 [COPYRIGHT]: COPYRIGHT

--- a/caddy/Caddyfile.dev
+++ b/caddy/Caddyfile.dev
@@ -1,9 +1,9 @@
 *:80
-root /srv/femiwiki.com
-index index.php
-fastcgi / fastcgi:9000 php
-gzip
-header / {
+root * /srv/femiwiki.com
+php_fastcgi fastcgi:9000
+file_server
+encode gzip
+header {
   # Enable XSS filtering for legacy browsers
   X-XSS-Protection "1; mode=block"
   # Block content sniffing, and enable Cross-Origin Read Blocking
@@ -11,15 +11,10 @@ header / {
   # Avoid clickjacking
   X-Frame-Options "DENY"
 }
-rewrite /w/api.php {
-  to /api.php
-}
-rewrite /w {
-  r  /(.*)
-  to /index.php
-}
+rewrite /w/api.php /api.php
+rewrite /w/* /index.php
 
 # Proxy requests to RESTBase
 # Reference:
 #   https://www.mediawiki.org/wiki/RESTBase/Installation#Proxy_requests_to_RESTBase_from_your_webserver
-proxy /femiwiki.com restbase:7231
+reverse_proxy /femiwiki.com/* restbase:7231

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,2 +1,2 @@
-0 1,5,9,13,17,21 * * * /usr/local/bin/generate-sitemap >> /tmp/log 2>&1
-0 5 */7 * * /usr/local/bin/localisation-update >> /tmp/log 2>&1
+0 1,5,9,13,17,21 * * * /usr/local/bin/generate-sitemap >> /tmp/log/cron 2>&1
+0 5 */7 * * /usr/local/bin/localisation-update >> /tmp/log/cron 2>&1

--- a/development.yml
+++ b/development.yml
@@ -7,6 +7,7 @@ services:
       - 80:80
       - 443:443
     volumes:
+      # Overwrite production Caddyfile
       - ./caddy/Caddyfile.dev:/srv/femiwiki.com/Caddyfile:ro
       - caddy:/etc/caddycerts
     environment:

--- a/development.yml
+++ b/development.yml
@@ -1,13 +1,13 @@
 version: '3'
 services:
   http:
-    image: ghcr.io/femiwiki/caddy:1.0.3
+    image: ghcr.io/femiwiki/mediawiki:latest
+    command: caddy run
     ports:
       - 80:80
       - 443:443
     volumes:
-      - ./caddy/Caddyfile.dev:/etc/Caddyfile:ro
-      - files:/srv/femiwiki.com
+      - ./caddy/Caddyfile.dev:/srv/femiwiki.com/Caddyfile:ro
       - caddy:/etc/caddycerts
     environment:
       - CADDYPATH=/etc/caddycerts
@@ -21,7 +21,6 @@ services:
     image: ghcr.io/femiwiki/mediawiki:latest
     volumes:
       - ./configs:/a:ro
-      - files:/srv/femiwiki.com
       - l18n_cache:/tmp/cache
       ## 스킨 등 개발할 때엔 아래 라인을 주석해제
       # - ../skin:/srv/femiwiki.com/skins/Femiwiki
@@ -60,7 +59,6 @@ services:
     image: wikimedia/mathoid:bad5ec8d4
 
 volumes:
-  files:
   database:
   caddy:
   l18n_cache:


### PR DESCRIPTION
> 1. docker-mediawiki 이미지에 caddy 바이너리, php-fpm 바이너리, PHP 소스코드 세개를 모두 넣은다음
> 2. docker run 할때에 CMD만 바꾸는 방식을 써서 caddy 도커 컨테이너와 php-fpm 도커 컨테이너를 따로 띄우기
> -- https://github.com/femiwiki/femiwiki/issues/116#issuecomment-707834452

Closes https://github.com/femiwiki/femiwiki/issues/190
