### PR TITLE
Dockerfile: Update caddy-mwcache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG MEDIAWIKI_VERSION=1.36.1
-ARG CADDY_MWCACHE_COMMIT=256dee73df22f736d6ceb0f0d9d27d4ff50249da
+ARG CADDY_MWCACHE_COMMIT=8322c2622509823908230c93ec3ba092d81e5015
 
 ARG TINI_VERSION=0.18.0
 
@@ -65,12 +65,11 @@ RUN COMPOSER_HOME=/tmp/composer composer update --no-dev --working-dir '/tmp/med
 #
 # Caddy 스테이지. Route53와 caddy-mwcache 패키지를 설치한 Caddy를 빌드한다.
 #
-FROM --platform=$TARGETPLATFORM caddy:2.4.3-builder AS caddy
+FROM --platform=$TARGETPLATFORM caddy:2.4.5-builder AS caddy
 ARG CADDY_MWCACHE_COMMIT
 
 RUN xcaddy build \
       --with github.com/caddy-dns/route53 \
-      --with github.com/dgraph-io/ristretto/010=github.com/dgraph-io/ristretto@v0.1.0 \
       --with "github.com/femiwiki/caddy-mwcache@${CADDY_MWCACHE_COMMIT}"
 
 #


### PR DESCRIPTION
TODOs
- [x] Wait until `caddy:2.4.4-builder` is released to the Docker Hub