### PR TITLE
Install QuickInstantCommons

### DIFF
--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -141,7 +141,8 @@ $wgSVGConverter = 'rsvg';
 $wgNativeImageLazyLoading = true;
 
 // InstantCommons allows wiki to use images from https://commons.wikimedia.org
-$wgUseInstantCommons = true;
+// We use Extension:QuickInstantCommons instead.
+$wgUseInstantCommons = false;
 
 // If you use ImageMagick (or any other shell command) on a
 // Linux server, this will need to be set to the name of an
@@ -840,6 +841,9 @@ wfLoadExtension( 'Poem' );
 wfLoadExtension( 'Popups' );
 $wgPopupsOptInDefaultState = '1';
 $wgDefaultUserOptions[ 'popupsreferencepreviews' ] = '1';
+
+// QuickInstantCommons
+wfLoadExtension( 'QuickInstantCommons' );
 
 // RelatedArticles
 wfLoadExtension( 'RelatedArticles' );

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -101,6 +101,9 @@
       "template": "https://github.com/femiwiki/FemiwikiSkin/releases/download/$1/$1.tar.gz",
       "version": "v1.10.3"
     },
+    "QuickInstantCommons": {
+      "template": "https://github.com/wikimedia/mediawiki-extensions-QuickInstantCommons/archive/3682cdee4a9f778f51a79f9ebc10c2bb9598c2ec.tar.gz"
+    },
     "AWS": {
       "template": "https://github.com/edwardspec/mediawiki-aws-s3/archive/v0.11.1.tar.gz"
     },

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -102,7 +102,8 @@
       "version": "v1.10.3"
     },
     "QuickInstantCommons": {
-      "template": "https://github.com/wikimedia/mediawiki-extensions-QuickInstantCommons/archive/refs/tags/v1.1.tar.gz"
+      "template": "https://github.com/wikimedia/mediawiki-extensions-QuickInstantCommons/archive/refs/tags/$1.tar.gz",
+      "version": "v1.1"
     },
     "AWS": {
       "template": "https://github.com/edwardspec/mediawiki-aws-s3/archive/v0.11.1.tar.gz"

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -102,7 +102,7 @@
       "version": "v1.10.3"
     },
     "QuickInstantCommons": {
-      "template": "https://github.com/wikimedia/mediawiki-extensions-QuickInstantCommons/archive/3682cdee4a9f778f51a79f9ebc10c2bb9598c2ec.tar.gz"
+      "template": "https://github.com/wikimedia/mediawiki-extensions-QuickInstantCommons/archive/refs/tags/v1.1.tar.gz"
     },
     "AWS": {
       "template": "https://github.com/edwardspec/mediawiki-aws-s3/archive/v0.11.1.tar.gz"


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Extension:QuickInstantCommons

I don't sure the extension has general availability.

Related to https://github.com/femiwiki/docker-mediawiki/issues/284