### PR TITLE
Install DarkMode extension

### DIFF
--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -517,7 +517,7 @@ $wgCaptchaTriggers['create'] = false;
 $wgCaptchaTriggers['addurl'] = false;
 $wgCaptchaTriggers['badlogin'] = false;
 
-// Darkmode
+// DarkMode
 wfLoadExtension( 'DarkMode' );
 $wgDarkModeTogglePosition = 'footer';
 

--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -517,6 +517,10 @@ $wgCaptchaTriggers['create'] = false;
 $wgCaptchaTriggers['addurl'] = false;
 $wgCaptchaTriggers['badlogin'] = false;
 
+// Darkmode
+wfLoadExtension( 'DarkMode' );
+$wgDarkModeTogglePosition = 'footer';
+
 // Description2
 wfLoadExtension( 'Description2' );
 

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -13,6 +13,7 @@
     "CodeEditor",
     "CodeMirror",
     "ConfirmEdit",
+    "DarkMode",
     "Description2",
     "DisableAccount",
     "Disambiguator",


### PR DESCRIPTION
Deploys DarkMode as...

- [T241925](https://phabricator.wikimedia.org/T241925)(Dark mode does not persist between pages) was resolved.
- [Miraheze](https://meta.miraheze.org/wiki/Miraheze) which is large, technically well-maintained, and has its development ecosystem is using DarkMode.

Related to https://github.com/femiwiki/femiwiki/issues/293
Previous attempt: https://github.com/femiwiki/femiwiki/issues/202