### PR TITLE
Use forked VE and Cite for citation dialog patches

### DIFF
--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -74,11 +74,11 @@
   "non-WMF": {
     "VisualEditor": {
       "@note": "See https://github.com/femiwiki/femiwiki/issues/296",
-      "template": "https://github.com/femiwiki/mediawiki-extensions-VisualEditor/archive/refs/heads/REL1_37.zip",
+      "template": "https://github.com/femiwiki/mediawiki-extensions-VisualEditor/archive/refs/heads/REL1_37.tar.gz",
     },
     "Cite": {
       "@note": "See https://github.com/femiwiki/femiwiki/issues/296",
-      "template": "https://github.com/femiwiki/mediawiki-extensions-Cite/archive/refs/heads/REL1_37.zip",
+      "template": "https://github.com/femiwiki/mediawiki-extensions-Cite/archive/refs/heads/REL1_37.tar.gz",
     },
     "AchievementBadges": {
       "template": "https://github.com/femiwiki/AchievementBadges/releases/download/$1/$1.tar.gz",

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -7,7 +7,6 @@
     "CategoryTree",
     "CharInsert",
     "CheckUser",
-    "Cite",
     "CiteThisPage",
     "Citoid",
     "CodeEditor",
@@ -65,7 +64,6 @@
     "UniversalLanguageSelector",
     "UploadWizard",
     "UserMerge",
-    "VisualEditor",
     "Widgets",
     "Wikibase",
     "WikiEditor"
@@ -74,6 +72,14 @@
     "Vector"
   ],
   "non-WMF": {
+    "VisualEditor": {
+      "@note": "See https://github.com/femiwiki/femiwiki/issues/296",
+      "template": "https://github.com/femiwiki/mediawiki-extensions-VisualEditor/archive/refs/heads/REL1_37.zip",
+    },
+    "Cite": {
+      "@note": "See https://github.com/femiwiki/femiwiki/issues/296",
+      "template": "https://github.com/femiwiki/mediawiki-extensions-Cite/archive/refs/heads/REL1_37.zip",
+    },
     "AchievementBadges": {
       "template": "https://github.com/femiwiki/AchievementBadges/releases/download/$1/$1.tar.gz",
       "version": "v0.3.0"

--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -74,11 +74,11 @@
   "non-WMF": {
     "VisualEditor": {
       "@note": "See https://github.com/femiwiki/femiwiki/issues/296",
-      "template": "https://github.com/femiwiki/mediawiki-extensions-VisualEditor/archive/refs/heads/REL1_37.tar.gz",
+      "template": "https://github.com/femiwiki/mediawiki-extensions-VisualEditor/archive/refs/heads/REL1_37.tar.gz"
     },
     "Cite": {
       "@note": "See https://github.com/femiwiki/femiwiki/issues/296",
-      "template": "https://github.com/femiwiki/mediawiki-extensions-Cite/archive/refs/heads/REL1_37.tar.gz",
+      "template": "https://github.com/femiwiki/mediawiki-extensions-Cite/archive/refs/heads/REL1_37.tar.gz"
     },
     "AchievementBadges": {
       "template": "https://github.com/femiwiki/AchievementBadges/releases/download/$1/$1.tar.gz",


### PR DESCRIPTION
The bug: https://github.com/femiwiki/femiwiki/issues/296 ([T291241](https://phabricator.wikimedia.org/T291241) on upstream)

- VE
  - https://github.com/femiwiki/mediawiki-extensions-VisualEditor/commit/633df2eca6d5e6fdd03ff9cccc14348103159803 is the backported commit.
- Cite
  - https://github.com/femiwiki/mediawiki-extensions-Cite/commit/4707e6d75ff4155e075eeff84fb24afaf505d132 is the backported commit.

Fixes https://github.com/femiwiki/femiwiki/issues/296