### PR TITLE
Set $wgWBRepoSettings['formatterUrlProperty']

### DIFF
--- a/configs/LocalSettings.php
+++ b/configs/LocalSettings.php
@@ -1061,6 +1061,7 @@ $wgWBRepoSettings['enableEntitySearchUI'] = false;
 $wgWBRepoSettings['siteLinkGroups'] = [ 'femiwiki' ];
 $wgWBRepoSettings['dataBridgeEnabled'] = true;
 $wgWBRepoSettings['conceptBaseUri'] = $wgCanonicalServer . str_replace( '$1', 'Item:', $wgArticlePath );
+$wgWBRepoSettings['formatterUrlProperty'] = 'P61';
 
 // WikiBase - client
 wfLoadExtension( 'WikibaseClient', "$IP/extensions/Wikibase/extension-client.json" );
@@ -1145,6 +1146,9 @@ if ( getenv( 'MEDIAWIKI_DEBUG_MODE' ) ) {
 	$wgCaptchaTriggers['addurl'] = false;
 	$wgCaptchaTriggers['createaccount'] = false;
 	$wgCaptchaTriggers['badlogin'] = false;
+
+	// 위키베이스 속성 초기화
+	$wgWBRepoSettings['formatterUrlProperty'] = null;
 
 	// Google Analytics 기록 비활성화
 	$wgPageViewInfoGATrackingID = false;


### PR DESCRIPTION
> #### formatterUrlProperty
> Property to be used on properties that defines a formatter URL which is used to link external identifiers.
>
> The placeholder `$1` will be replaced by the identifier.
> When formatting identifiers, each identifier's property page is checked for its formatter URL (e.g. `http://d-nb.info/gnd/$1`) specified by the property from this setting.
> 
> EXAMPLE: On wikidata.org, this is set to `P1630`, a string property named “formatter URL”.
https://gerrit.wikimedia.org/g/mediawiki/extensions/Wikibase/+/eec103fe0717f86135ff7c1e04467719c89de8cb/docs/topics/options.md#formatterurlproperty