### PR TITLE
Bump EmbedVideo to v3.2.6

### DIFF
--- a/extension-installer/extensions.json
+++ b/extension-installer/extensions.json
@@ -112,7 +112,7 @@
     },
     "EmbedVideo": {
       "template": "https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo/archive/refs/tags/$1.tar.gz",
-      "version": "v3.1.0"
+      "version": "v3.2.6"
     },
     "GoogleSiteSearch": {
       "template": "https://github.com/wikimedia/mediawiki-extensions-GoogleSiteSearch/archive/$1.tar.gz",


### PR DESCRIPTION
### [EmbedVideo v3.2.6](https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo/releases/tag/v3.2.6)

> - Remove double spaces from English messages
> - Create es.json
> - feat: add Korean language file(ko.json)
> - fixed getUrl() for Bilibili
> - feat: Default to render inline
> - When explicit consent is active, iFrames are now generated on the client rather than being generated on the server

### [EmbedVideo v3.2.1](https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo/releases/tag/v3.2.1)

> This is another small bugfix release.
> 
> In v3.2.0 external thumbnails were fetched, even if it was disabled; this release fixes that.
> 
> This release has been tested with MW 1.39.1

### [EmbedVideo v3.2.0](https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo/releases/tag/v3.2.0)

> This release changes the DOM structure of the output!