### PR TITLE
Remove EventLogging

### DIFF
--- a/dockers/femiwiki-extensions/README.md
+++ b/dockers/femiwiki-extensions/README.md
@@ -2,6 +2,11 @@
 
 This docker image contains MediaWiki extensions Femiwiki uses.
 
+## v2.4.3
+
+- Remove EventLogging. It was installed only as a dependency of DiscussionTools,
+  which no longer requires it.
+
 ## v2.4.2
 
 - Bump AWS to v0.14.0

--- a/dockers/femiwiki-extensions/extension-installer/extensions.json
+++ b/dockers/femiwiki-extensions/extension-installer/extensions.json
@@ -23,7 +23,6 @@
     "DiscussionTools",
     "DismissableSiteNotice",
     "Echo",
-    "EventLogging",
     "FacetedCategory",
     "FlaggedRevs",
     "Flow",

--- a/dockers/femiwiki/LocalSettings.php
+++ b/dockers/femiwiki/LocalSettings.php
@@ -551,9 +551,6 @@ $wgEchoPerUserBlacklist = true;
 // EmbedVideo
 wfLoadExtension( 'EmbedVideo' );
 
-// EventLogging
-wfLoadExtension( 'EventLogging' );
-
 // FacetedCategory
 wfLoadExtension( 'FacetedCategory' );
 


### PR DESCRIPTION
Closes #484

We installed EventLogging in 2021 only because DiscussionTools required it (T275157). In REL1_43, DiscussionTools only requires VisualEditor and Linter. We never configured EventLogging itself, so it was collecting nothing.

The original 2024 commit was rewritten on top of the current main:

- The workflow no longer uses a `TAG` env. The version now comes from the first `## v` heading in the README, so this PR adds a `## v2.4.3` entry there.
- Removing the extension from the image alone would break the wiki at load time, so this PR also removes `wfLoadExtension( 'EventLogging' );` from `LocalSettings.php`.

## Verification (source code based)

Checked the REL1_43 sources (pinned tags for third-party) of all 86 installed extensions and skins:

- No extension lists EventLogging in `requires`.
- No ResourceLoader module depends on `ext.eventLogging`, so no JS module breaks.
- All PHP code that uses EventLogging classes (WikiEditor, DiscussionTools, TwoColConflict, TemplateData, Translate, CheckUser, GrowthExperiments) is behind `ExtensionRegistry::isLoaded( 'EventLogging' )` checks.
- The only unguarded path is UploadWizard's `CampaignContent::validate()`. It only runs when someone edits a page in the `Campaign:` namespace, and femiwiki has zero such pages (checked with `api.php?action=query&list=allpages&apnamespace=460`). If we ever start using UploadWizard campaigns, we need to install EventLogging again.

Deploy order is safe in both directions. If the femiwiki image ships first, the extension stays in the image but is simply not loaded. When the extensions image v2.4.3 lands later, the load line is already gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
