### PR TITLE
extensions: add to mw-extenstion FemiwikiCrawlingBlocker

### DIFF
--- a/dockers/femiwiki-extensions/README.md
+++ b/dockers/femiwiki-extensions/README.md
@@ -2,6 +2,10 @@
 
 This docker image contains MediaWiki extensions Femiwiki uses.
 
+## v2.3.0
+
+- Add to mw-extenstion FemiwikiCrawlingBlocker
+
 ## v2.2.7
 
 - Bump UnlinkedWikibase to v3.3.1

--- a/dockers/femiwiki-extensions/extension-installer/extensions.json
+++ b/dockers/femiwiki-extensions/extension-installer/extensions.json
@@ -98,6 +98,10 @@
       "template": "https://github.com/femiwiki/FemiwikiSkin/releases/download/$1/$1.tar.gz",
       "version": "v5.1.2"
     },
+    "FemiwikiCrawlingBlocker": {
+      "template": "https://github.com/femiwiki/mediawiki-extensions-FemiwikiCrawlingBlocker/archive/refs/tags/$1.tar.gz",
+      "version": "v1.0.0"
+    },
     "AWS": {
       "template": "https://github.com/edwardspec/mediawiki-aws-s3/archive/refs/tags/$1.tar.gz",
       "version": "v0.13.1"

--- a/dockers/femiwiki-extensions/extension-installer/extensions.json
+++ b/dockers/femiwiki-extensions/extension-installer/extensions.json
@@ -99,8 +99,8 @@
       "version": "v5.1.2"
     },
     "FemiwikiCrawlingBlocker": {
-      "template": "https://github.com/femiwiki/mediawiki-extensions-FemiwikiCrawlingBlocker/archive/refs/tags/$1.tar.gz",
-      "version": "v1.0.0"
+      "template": "https://github.com/femiwiki/FemiwikiCrawlingBlocker/archive/refs/tags/$1.tar.gz",
+      "version": "v2.0.0"
     },
     "AWS": {
       "template": "https://github.com/edwardspec/mediawiki-aws-s3/archive/refs/tags/$1.tar.gz",


### PR DESCRIPTION
The extension is designed to block bots optimized for crawling Femiwiki, enhancing site performance and preventing unnecessary traffic.