### PR TITLE
refactor(ci): build multi-platform docker images on native runners

### DIFF
--- a/.github/workflows/docker-caddy.yml
+++ b/.github/workflows/docker-caddy.yml
@@ -12,12 +12,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker-image:
+  get-version:
     runs-on: ubuntu-latest
+    outputs:
+      ver: ${{ steps.get-version.outputs.ver }}
     steps:
       - uses: actions/checkout@v4
+      - id: get-version
+        run: echo "ver=$(grep '## v' dockers/caddy/README.md | head -n 1 | cut -d'v' -f2)" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-qemu-action@v3
+  build:
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            os: ubuntu-latest-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
@@ -28,29 +44,43 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: get-version
-        run: echo "ver=$(grep '## v' dockers/caddy/README.md | head -n 1 | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
       - uses: docker/build-push-action@v6
         with:
           context: '{{ defaultContext }}:dockers/caddy'
-          platforms: linux/amd64,linux/arm64
-          cache-from: ghcr.io/femiwiki/caddy:latest
+          platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=ghcr.io/femiwiki/caddy:latest
           load: false
           push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/femiwiki/caddy:latest
-            ghcr.io/femiwiki/caddy:${{ steps.get-version.outputs.ver }}
+            ghcr.io/femiwiki/caddy:${{ needs.get-version.outputs.ver }}-${{ replace(matrix.platform, 'linux/', '') }}
+            ghcr.io/femiwiki/caddy:latest-${{ replace(matrix.platform, 'linux/', '') }}
+
+  push-manifest:
+    needs: [get-version, build]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push manifest
+        run: |
+          docker manifest create ghcr.io/femiwiki/caddy:latest ghcr.io/femiwiki/caddy:latest-amd64 ghcr.io/femiwiki/caddy:latest-arm64
+          docker manifest push ghcr.io/femiwiki/caddy:latest
+          docker manifest create ghcr.io/femiwiki/caddy:${{ needs.get-version.outputs.ver }} ghcr.io/femiwiki/caddy:${{ needs.get-version.outputs.ver }}-amd64 ghcr.io/femiwiki/caddy:${{ needs.get-version.outputs.ver }}-arm64
+          docker manifest push ghcr.io/femiwiki/caddy:${{ needs.get-version.outputs.ver }}
 
       - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          version: ${{ needs.get-version.outputs.ver }}
           upstream: caddy
           downstream: femiwiki
 
       - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
@@ -58,10 +88,9 @@ jobs:
 
       - name: Create Pull Request
         id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump femiwiki docker image
-          title: 'femiwiki: Bump caddy docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-caddy-v${{ steps.get-version.outputs.ver }}-femiwiki
+          title: 'femiwiki: Bump caddy docker image to v${{ needs.get-version.outputs.ver }}'
+          branch: bump-caddy-v${{ needs.get-version.outputs.ver }}-femiwiki

--- a/.github/workflows/docker-femiwiki-extensions.yml
+++ b/.github/workflows/docker-femiwiki-extensions.yml
@@ -16,12 +16,30 @@ concurrency:
   cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
-  docker-image:
+  get-version:
     runs-on: ubuntu-latest
+    outputs:
+      ver: ${{ steps.get-version.outputs.ver }}
     steps:
       - uses: actions/checkout@v4
+      - id: get-version
+        run: echo "ver=$(grep -m 1 '## v' dockers/femiwiki-extensions/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-qemu-action@v3
+  build:
+    # This image only contains PHP code, so there is no difference in building it for each platform.
+    # However, we build them in parallel on native runners for consistency with other workflows.
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            os: ubuntu-latest-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
@@ -32,29 +50,43 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: get-version
-        run: echo "ver=$(grep -m 1 '## v' dockers/femiwiki-extensions/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
       - uses: docker/build-push-action@v6
         with:
           context: '{{ defaultContext }}:dockers/femiwiki-extensions'
-          platforms: linux/amd64
-          cache-from: ghcr.io/femiwiki/femiwiki-extensions:latest
+          platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=ghcr.io/femiwiki/femiwiki-extensions:latest
           load: false
           push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/femiwiki/femiwiki-extensions:latest
-            ghcr.io/femiwiki/femiwiki-extensions:${{ steps.get-version.outputs.ver }}
+            ghcr.io/femiwiki/femiwiki-extensions:${{ needs.get-version.outputs.ver }}-${{ replace(matrix.platform, 'linux/', '') }}
+            ghcr.io/femiwiki/femiwiki-extensions:latest-${{ replace(matrix.platform, 'linux/', '') }}
+
+  push-manifest:
+    needs: [get-version, build]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push manifest
+        run: |
+          docker manifest create ghcr.io/femiwiki/femiwiki-extensions:latest ghcr.io/femiwiki/femiwiki-extensions:latest-amd64 ghcr.io/femiwiki/femiwiki-extensions:latest-arm64
+          docker manifest push ghcr.io/femiwiki/femiwiki-extensions:latest
+          docker manifest create ghcr.io/femiwiki/femiwiki-extensions:${{ needs.get-version.outputs.ver }} ghcr.io/femiwiki/femiwiki-extensions:${{ needs.get-version.outputs.ver }}-amd64 ghcr.io/femiwiki/femiwiki-extensions:${{ needs.get-version.outputs.ver }}-arm64
+          docker manifest push ghcr.io/femiwiki/femiwiki-extensions:${{ needs.get-version.outputs.ver }}
 
       - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          version: ${{ needs.get-version.outputs.ver }}
           upstream: femiwiki-extensions
           downstream: femiwiki
 
       - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
@@ -62,10 +94,9 @@ jobs:
 
       - name: Create Pull Request
         id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump femiwiki-extensions docker image
-          title: 'femiwiki: Bump femiwiki-extensions docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-femiwiki-extensions-v${{ steps.get-version.outputs.ver }}-femiwiki
+          title: 'femiwiki: Bump femiwiki-extensions docker image to v${{ needs.get-version.outputs.ver }}'
+          branch: bump-femiwiki-extensions-v${{ needs.get-version.outputs.ver }}-femiwiki

--- a/.github/workflows/docker-femiwiki.yml
+++ b/.github/workflows/docker-femiwiki.yml
@@ -16,12 +16,20 @@ concurrency:
   cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
-  docker-image:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - run: |
+          echo "version=$(date +%Y-%m-%dT%H-%M)-$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
+        id: version
+
+  test-and-build-amd64:
+    needs: get-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -30,10 +38,6 @@ jobs:
           mv dockers/femiwiki/LocalSettings.php development
           mv dockers/femiwiki/Hotfix.php development
           sed -i -r 's~ghcr\.io\/femiwiki\/femiwiki:.+~ghcr\.io\/femiwiki\/femiwiki:docker-test~' compose.yml
-
-      - run: |
-          echo "version=$(date +%Y-%m-%dT%H-%M)-$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
-        id: version
 
       - uses: docker/build-push-action@v6
         with:
@@ -102,17 +106,61 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build a multi-platform docker image and push
+      - name: Build and push amd64 image
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: '{{defaultContext}}:dockers/femiwiki'
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: |
             ghcr.io/femiwiki/femiwiki:latest
             type=local,src=/tmp/.buildx-cache
           cache-to: mode=max,type=inline
           load: false
-          push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+          push: true
           tags: |
-            ghcr.io/femiwiki/femiwiki:latest
-            ghcr.io/femiwiki/femiwiki:${{ steps.version.outputs.version }}
+            ghcr.io/femiwiki/femiwiki:latest-amd64
+            ghcr.io/femiwiki/femiwiki:${{ needs.get-version.outputs.version }}-amd64
+
+  build-arm64:
+    needs: get-version
+    runs-on: ubuntu-latest-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push arm64 image
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: '{{defaultContext}}:dockers/femiwiki'
+          platforms: linux/arm64
+          cache-from: ghcr.io/femiwiki/femiwiki:latest
+          cache-to: mode=max,type=inline
+          load: false
+          push: true
+          tags: |
+            ghcr.io/femiwiki/femiwiki:latest-arm64
+            ghcr.io/femiwiki/femiwiki:${{ needs.get-version.outputs.version }}-arm64
+
+  push-manifest:
+    needs: [get-version, test-and-build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push manifest
+        run: |
+          docker manifest create ghcr.io/femiwiki/femiwiki:latest ghcr.io/femiwiki/femiwiki:latest-amd64 ghcr.io/femiwiki/femiwiki:latest-arm64
+          docker manifest push ghcr.io/femiwiki/femiwiki:latest
+          docker manifest create ghcr.io/femiwiki/femiwiki:${{ needs.get-version.outputs.version }} ghcr.io/femiwiki/femiwiki:${{ needs.get-version.outputs.version }}-amd64 ghcr.io/femiwiki/femiwiki:${{ needs.get-version.outputs.version }}-arm64
+          docker manifest push ghcr.io/femiwiki/femiwiki:${{ needs.get-version.outputs.version }}

--- a/.github/workflows/docker-mediawiki.yml
+++ b/.github/workflows/docker-mediawiki.yml
@@ -12,12 +12,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker-image:
+  get-version:
     runs-on: ubuntu-latest
+    outputs:
+      ver: ${{ steps.get-version.outputs.ver }}
     steps:
       - uses: actions/checkout@v4
+      - id: get-version
+        run: echo "ver=$(grep -m 1 '## v' dockers/mediawiki/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-qemu-action@v3
+  build:
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            os: ubuntu-latest-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
@@ -28,29 +44,43 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: get-version
-        run: echo "ver=$(grep -m 1 '## v' dockers/mediawiki/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
       - uses: docker/build-push-action@v6
         with:
           context: '{{ defaultContext }}:dockers/mediawiki'
-          platforms: linux/amd64,linux/arm64
-          cache-from: ghcr.io/femiwiki/mediawiki:latest
+          platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=ghcr.io/femiwiki/mediawiki:latest
           load: false
           push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/femiwiki/mediawiki:latest
-            ghcr.io/femiwiki/mediawiki:${{ steps.get-version.outputs.ver }}
+            ghcr.io/femiwiki/mediawiki:${{ needs.get-version.outputs.ver }}-${{ replace(matrix.platform, 'linux/', '') }}
+            ghcr.io/femiwiki/mediawiki:latest-${{ replace(matrix.platform, 'linux/', '') }}
+
+  push-manifest:
+    needs: [get-version, build]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push manifest
+        run: |
+          docker manifest create ghcr.io/femiwiki/mediawiki:latest ghcr.io/femiwiki/mediawiki:latest-amd64 ghcr.io/femiwiki/mediawiki:latest-arm64
+          docker manifest push ghcr.io/femiwiki/mediawiki:latest
+          docker manifest create ghcr.io/femiwiki/mediawiki:${{ needs.get-version.outputs.ver }} ghcr.io/femiwiki/mediawiki:${{ needs.get-version.outputs.ver }}-amd64 ghcr.io/femiwiki/mediawiki:${{ needs.get-version.outputs.ver }}-arm64
+          docker manifest push ghcr.io/femiwiki/mediawiki:${{ needs.get-version.outputs.ver }}
 
       - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          version: ${{ needs.get-version.outputs.ver }}
           upstream: mediawiki
           downstream: femiwiki
 
       - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
@@ -58,10 +88,9 @@ jobs:
 
       - name: Create Pull Request
         id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump mediawiki docker image
-          title: 'femiwiki: Bump mediawiki docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-mediawiki-v${{ steps.get-version.outputs.ver }}-femiwiki
+          title: 'femiwiki: Bump mediawiki docker image to v${{ needs.get-version.outputs.ver }}'
+          branch: bump-mediawiki-v${{ needs.get-version.outputs.ver }}-femiwiki

--- a/.github/workflows/docker-php-fpm.yml
+++ b/.github/workflows/docker-php-fpm.yml
@@ -12,12 +12,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker-image:
+  get-version:
     runs-on: ubuntu-latest
+    outputs:
+      ver: ${{ steps.get-version.outputs.ver }}
     steps:
       - uses: actions/checkout@v4
+      - id: get-version
+        run: echo "ver=$(grep -m 1 '## v' dockers/php-fpm/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-qemu-action@v3
+  build:
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            os: ubuntu-latest-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
@@ -28,29 +44,43 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: get-version
-        run: echo "ver=$(grep -m 1 '## v' dockers/php-fpm/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
       - uses: docker/build-push-action@v6
         with:
           context: '{{ defaultContext }}:dockers/php-fpm'
-          platforms: linux/amd64,linux/arm64
-          cache-from: ghcr.io/femiwiki/php-fpm:latest
+          platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=ghcr.io/femiwiki/php-fpm:latest
           load: false
           push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
           tags: |
-            ghcr.io/femiwiki/php-fpm:latest
-            ghcr.io/femiwiki/php-fpm:${{ steps.get-version.outputs.ver }}
+            ghcr.io/femiwiki/php-fpm:${{ needs.get-version.outputs.ver }}-${{ replace(matrix.platform, 'linux/', '') }}
+            ghcr.io/femiwiki/php-fpm:latest-${{ replace(matrix.platform, 'linux/', '') }}
+
+  push-manifest:
+    needs: [get-version, build]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push manifest
+        run: |
+          docker manifest create ghcr.io/femiwiki/php-fpm:latest ghcr.io/femiwiki/php-fpm:latest-amd64 ghcr.io/femiwiki/php-fpm:latest-arm64
+          docker manifest push ghcr.io/femiwiki/php-fpm:latest
+          docker manifest create ghcr.io/femiwiki/php-fpm:${{ needs.get-version.outputs.ver }} ghcr.io/femiwiki/php-fpm:${{ needs.get-version.outputs.ver }}-amd64 ghcr.io/femiwiki/php-fpm:${{ needs.get-version.outputs.ver }}-arm64
+          docker manifest push ghcr.io/femiwiki/php-fpm:${{ needs.get-version.outputs.ver }}
 
       - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          version: ${{ needs.get-version.outputs.ver }}
           upstream: php-fpm
           downstream: mediawiki
 
       - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
@@ -58,13 +88,12 @@ jobs:
 
       - name: Create Pull Request
         id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump php-fpm docker image
-          title: 'mediawiki: Bump php-fpm docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-php-fpm-v${{ steps.get-version.outputs.ver }}-femiwiki
+          title: 'mediawiki: Bump php-fpm docker image to v${{ needs.get-version.outputs.ver }}'
+          branch: bump-php-fpm-v${{ needs.get-version.outputs.ver }}-femiwiki
 
       - name: Enable Pull Request Automerge
         if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Authored by `gemini-2.5-pro`

> This commit refactors the Docker image build workflows to use native amd64 and arm64 runners in parallel, instead of relying on QEMU for cross-compilation.
> 
> This speeds up the build process and leverages the newly available ARM runners on GitHub Actions.