### PR TITLE
chore: bump UnifiedExtensionForFemiwiki to v5.0.0

### DIFF
--- a/dockers/femiwiki-extensions/README.md
+++ b/dockers/femiwiki-extensions/README.md
@@ -2,6 +2,10 @@
 
 This docker image contains MediaWiki extensions Femiwiki uses.
 
+## v2.4.1
+
+- Bump UnifiedExtensionForFemiwiki to v5.0.0
+
 ## v2.4.0
 
 - Install Lockdown

--- a/dockers/femiwiki-extensions/extension-installer/extensions.json
+++ b/dockers/femiwiki-extensions/extension-installer/extensions.json
@@ -92,7 +92,7 @@
     },
     "UnifiedExtensionForFemiwiki": {
       "template": "https://github.com/femiwiki/UnifiedExtensionForFemiwiki/archive/$1.tar.gz",
-      "version": "a20ed49e018e23316aedcb47c94fd4c1576c5c45"
+      "version": "v5.0.0"
     },
     "Femiwiki": {
       "type": "skin",


### PR DESCRIPTION
## What
Bump the pinned `UnifiedExtensionForFemiwiki` from commit `a20ed49` (2025-01-20) to the freshly cut release **v5.0.0**.

## Why
The pin was ~17 months / 26 commits stale while the extension is actively maintained. v5.0.0 is the first proper release on the current `main` lineage and ships, notably, `fix: Replace removed Wikibase ClientHooks with stable API` (#220 upstream), reducing breakage risk as Wikibase tracks REL1_43 tip.

## Verification
- Extension CI is green for `REL1_43` (current production) through `master`.
- `archive/v5.0.0.tar.gz` resolves (HTTP 200) and its `extension.json` reports `5.0.0`.

The new-release plumbing (release-please) was unblocked separately; legacy `v4.x` tags were left intact.