### PR TITLE
chore: auto-sync femiwiki-extensions README via a shared changelog action

### DIFF
--- a/.github/actions/add-changelog-entry/action.yml
+++ b/.github/actions/add-changelog-entry/action.yml
@@ -1,0 +1,54 @@
+name: Add changelog entry
+description: >
+  Prepend a new "## vX.Y.(Z+1)" entry to a docker image's README.md, which is
+  the source of truth for that image's tag. Records one bullet per non-empty
+  line of `message`. Idempotent (skips if the first bullet is already present)
+  and header-length agnostic, so any image workflow can reuse it.
+
+inputs:
+  image:
+    description: Image directory under dockers/ whose README.md to update.
+    required: true
+  message:
+    description: One changelog bullet per non-empty line (the leading "- " is added).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        set -euo pipefail
+        README="dockers/${IMAGE}/README.md"
+
+        bullets=""
+        while IFS= read -r line; do
+          [ -z "$line" ] && continue
+          bullets+="- ${line}"$'\n'
+        done <<< "$MESSAGE"
+        if [ -z "$bullets" ]; then
+          echo "add-changelog-entry: empty message, nothing to do"
+          exit 0
+        fi
+
+        first_bullet=$(printf '%s' "$bullets" | head -n1)
+        if grep -qF -- "$first_bullet" "$README"; then
+          echo "add-changelog-entry: '${first_bullet}' already present, skipping"
+          exit 0
+        fi
+
+        cur=$(grep -m1 '^## v' "$README" | sed 's/^## v//')
+        IFS=. read -r ma mi pa <<< "$cur"
+        next="${ma}.${mi}.$((pa + 1))"
+
+        line_no=$(grep -n -m1 '^## v' "$README" | cut -d: -f1)
+        {
+          head -n "$((line_no - 1))" "$README"
+          printf '## v%s\n\n%s\n' "$next" "$bullets"
+          tail -n "+${line_no}" "$README"
+        } > "${README}.tmp"
+        mv -f "${README}.tmp" "$README"
+        echo "add-changelog-entry: added v${next} to ${README}"

--- a/.github/workflows/bump-extension.yml
+++ b/.github/workflows/bump-extension.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Update extensions.json
         run: ruby .github/bump_extension.rb '${{fromJSON(steps.vars.outputs.result).ext}}' '${{fromJSON(steps.vars.outputs.result).ver}}'
 
+      - name: Update README
+        uses: ./.github/actions/add-changelog-entry
+        with:
+          image: femiwiki-extensions
+          message: Bump ${{fromJSON(steps.vars.outputs.result).ext}} to ${{fromJSON(steps.vars.outputs.result).ver}}
+
       - uses: peter-murray/workflow-application-token-action@v4
         if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
         id: get_workflow_token

--- a/.github/workflows/sync-extension-readme.yml
+++ b/.github/workflows/sync-extension-readme.yml
@@ -1,0 +1,70 @@
+name: Sync extension README
+
+# When a PR bumps an extension in extensions.json but forgets to add the
+# matching dockers/femiwiki-extensions/README.md entry (which drives the image
+# tag), add it automatically and push it back to the PR branch.
+
+on:
+  pull_request:
+    paths:
+      - dockers/femiwiki-extensions/extension-installer/extensions.json
+
+permissions:
+  contents: write
+
+jobs:
+  sync-readme:
+    # A workflow cannot push to a fork's branch, so only handle same-repo PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: peter-murray/workflow-application-token-action@v4
+        id: get_workflow_token
+        with:
+          application_id: ${{ vars.PAT_APPLICATION_ID }}
+          application_private_key: ${{ secrets.PAT_APPLICATION_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.get_workflow_token.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Compute changed extensions
+        id: diff
+        run: |
+          ext=dockers/femiwiki-extensions/extension-installer/extensions.json
+          git show "origin/${{ github.base_ref }}:${ext}" > "${RUNNER_TEMP}/base.json"
+          msg=$(jq -r -n \
+            --slurpfile b "${RUNNER_TEMP}/base.json" \
+            --slurpfile h "$ext" '
+              ($h[0]["non-WMF"]) as $head | ($b[0]["non-WMF"]) as $base
+              | [ $head | to_entries[]
+                  | select(($base[.key].version // "") != .value.version)
+                  | .value.version as $v
+                  | "Bump \(.key) to \(if ($v|test("^v")) then $v elif ($v|test("^[0-9]")) then "v"+$v else $v end)" ]
+              | join("\n")')
+          {
+            echo "msg<<__EOF__"
+            echo "$msg"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add README entry
+        if: steps.diff.outputs.msg != ''
+        uses: ./.github/actions/add-changelog-entry
+        with:
+          image: femiwiki-extensions
+          message: ${{ steps.diff.outputs.msg }}
+
+      - name: Commit and push if changed
+        run: |
+          if [ -z "$(git status --porcelain dockers/femiwiki-extensions/README.md)" ]; then
+            echo 'README already up to date.'
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add dockers/femiwiki-extensions/README.md
+          git commit -m 'chore: auto-add femiwiki-extensions README changelog entry'
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
## What
Make `dockers/femiwiki-extensions/README.md` update itself on extension bumps, using a **shared, image-agnostic bash composite action** (not Ruby) so other images (mediawiki, caddy, ...) can reuse it.

## Why
The image tag is derived from the top `## v` heading of the image README, so an extension bump needs a new README entry. Doing the README logic in Ruby would not be shareable with the rest of the image workflows, which already use a bash composite action (`add-nev-version-entry-to-changelog`).

## How
- **`actions/add-changelog-entry`** new composite action: `image` + `message` inputs, prepends a `## vX.Y.(Z+1)` entry (one bullet per message line). Idempotent (skips if the first bullet already exists) and header-length agnostic, so any image workflow can call it.
- **`bump-extension.yml`** calls the action after `bump_extension.rb`, so the bump-extension flow yields a complete PR.
- **`sync-extension-readme.yml`** guard: on any PR that changes `extensions.json` without the matching README entry, it derives the changed extension(s) from the base..head diff with `jq` and pushes the entry back to the PR branch. Same-repo PRs only; uses the existing `PAT_APPLICATION_ID` app token.
- `bump_extension.rb` is left as-is (it only edits `extensions.json`).

## Verified locally
- Prepend logic on both a 3-line-header README (femiwiki-extensions) and a 2-line-header README (mediawiki); idempotent re-run is a no-op; multiline message yields multiple bullets under one entry.
- `jq` diff detects changed extensions and normalizes the `v` prefix (`3.4.0` -> `v3.4.0`, `v5.0.0` kept, commit hash left as-is).

## Follow-up (not in this PR)
The existing `add-nev-version-entry-to-changelog` action could later be refactored onto this primitive to remove duplication (and would also fix its 2-line-header assumption).