### PR TITLE
extensions: bump third-party deps and drop FemiwikiCrawlingBlocker

### DIFF
--- a/dockers/femiwiki-extensions/README.md
+++ b/dockers/femiwiki-extensions/README.md
@@ -2,6 +2,12 @@
 
 This docker image contains MediaWiki extensions Femiwiki uses.
 
+## v2.4.2
+
+- Bump AWS to v0.14.0
+- Bump UnlinkedWikibase to v4.0.0
+- Remove FemiwikiCrawlingBlocker
+
 ## v2.4.1
 
 - Bump UnifiedExtensionForFemiwiki to v5.0.0

--- a/dockers/femiwiki-extensions/extension-installer/extensions.json
+++ b/dockers/femiwiki-extensions/extension-installer/extensions.json
@@ -88,7 +88,7 @@
   "non-WMF": {
     "UnlinkedWikibase": {
       "template": "https://github.com/wikimedia/mediawiki-extensions-UnlinkedWikibase/archive/refs/tags/$1.tar.gz",
-      "version": "3.3.1"
+      "version": "4.0.0"
     },
     "UnifiedExtensionForFemiwiki": {
       "template": "https://github.com/femiwiki/UnifiedExtensionForFemiwiki/archive/$1.tar.gz",
@@ -99,13 +99,9 @@
       "template": "https://github.com/femiwiki/FemiwikiSkin/releases/download/$1/$1.tar.gz",
       "version": "v5.1.2"
     },
-    "FemiwikiCrawlingBlocker": {
-      "template": "https://github.com/femiwiki/FemiwikiCrawlingBlocker/archive/refs/tags/$1.tar.gz",
-      "version": "v2.0.1"
-    },
     "AWS": {
       "template": "https://github.com/edwardspec/mediawiki-aws-s3/archive/refs/tags/$1.tar.gz",
-      "version": "v0.13.1"
+      "version": "v0.14.0"
     },
     "EmbedVideo": {
       "template": "https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo/archive/refs/tags/$1.tar.gz",

--- a/dockers/femiwiki/LocalSettings.php
+++ b/dockers/femiwiki/LocalSettings.php
@@ -557,10 +557,6 @@ wfLoadExtension( 'EventLogging' );
 // FacetedCategory
 wfLoadExtension( 'FacetedCategory' );
 
-// FemiwikiCrawlingBlocker
-wfLoadExtension( 'FemiwikiCrawlingBlocker' );
-$wgFemiwikiCrawlingBlockerEnabled = true;
-
 // FlaggedRevs
 wfLoadExtension( 'FlaggedRevs' );
 $wgFlaggedRevsNamespaces = [
@@ -1080,7 +1076,6 @@ if ( getenv( 'MEDIAWIKI_DEBUG_MODE' ) ) {
 	$wgCaptchaTriggers['addurl'] = false;
 	$wgCaptchaTriggers['createaccount'] = false;
 	$wgCaptchaTriggers['badlogin'] = false;
-	$wgFemiwikiCrawlingBlockerEnabled = false;
 
 	// 위키베이스 속성 초기화
 	$wgWBRepoSettings['formatterUrlProperty'] = null;


### PR DESCRIPTION
## Third-party version bumps (MW 1.43-compatible)
Frozen pins were not getting fixes. Bumped the ones whose newer versions still target 1.43:

| Extension | Old | New | requires |
|---|---|---|---|
| AWS (mediawiki-aws-s3) | v0.13.1 | **v0.14.0** | `>= 1.43.0` |
| UnlinkedWikibase | 3.3.1 | **4.0.0** | `>= 1.43` |

Both tarballs resolve (HTTP 200). UnlinkedWikibase 4.0.0 is a major bump — worth a smoke test on staging.

**EmbedVideo held**: left at v3.4.3. Its only maintained line is v4.x (a breaking rewrite of the `<embedvideo>` syntax/config), so it needs separate wiki-content testing before bumping. Tracked for a follow-up PR.

## Drop FemiwikiCrawlingBlocker
Superseded by the env-driven CrawlerProtection / `BLOCKED_CIDR` blocking. It was loaded+enabled in prod (`LocalSettings.php`) and only disabled in the dev block. Removed:
- the `extensions.json` install entry
- `wfLoadExtension( 'FemiwikiCrawlingBlocker' )` + `$wgFemiwikiCrawlingBlockerEnabled = true`
- the dev-block `$wgFemiwikiCrawlingBlockerEnabled = false` line

Image changelog bumped to `v2.4.2`.