### PR TITLE
build(caddy): bump Caddy to v2.11.4 and pin caddy-mwcache v0.1.0

### DIFF
--- a/dockers/caddy/Dockerfile
+++ b/dockers/caddy/Dockerfile
@@ -1,9 +1,9 @@
 FROM --platform=$TARGETPLATFORM caddy:2-builder AS caddy
-ARG CADDY_MWCACHE_COMMIT=9e9ac234170400406c6a328bbaaaa4c95e05bd73
+ARG CADDY_MWCACHE_VERSION=v0.1.0
 ARG CADDY_CERTMAGIC_S3_COMMIT=62a3ac98984dae7208ba2c126ecf6b0bf638dfa6
 
-RUN XCADDY_DEBUG=1 xcaddy build v2.8.4 \
+RUN XCADDY_DEBUG=1 xcaddy build v2.11.4 \
       --with github.com/caddy-dns/route53 \
-      --with "github.com/femiwiki/caddy-mwcache@${CADDY_MWCACHE_COMMIT}" \
+      --with "github.com/femiwiki/caddy-mwcache@${CADDY_MWCACHE_VERSION}" \
       --with "github.com/ss098/certmagic-s3@${CADDY_CERTMAGIC_S3_COMMIT}" \
       ;

--- a/dockers/caddy/README.md
+++ b/dockers/caddy/README.md
@@ -2,6 +2,11 @@
 
 Route53와 caddy-mwcache 패키지를 설치한 Caddy를 빌드한다.
 
+## v1.4.0
+
+- Bump Caddy from v2.8.4 to v2.11.4
+- Bump caddy-mwcache to v0.1.0
+
 ## v1.3.3
 
 - Downgrade Caddy from v2.9.1 to v2.8.4


### PR DESCRIPTION
## Summary

Bumps the `ghcr.io/femiwiki/caddy` image to the latest Caddy and pins caddy-mwcache to a proper release tag.

- `xcaddy build v2.8.4` → `v2.11.4` (reverses the temporary v1.3.3 downgrade)
- caddy-mwcache pinned to **v0.1.0** (femiwiki/caddy-mwcache's first tagged release since 2021) instead of a raw commit hash
- ARG renamed `CADDY_MWCACHE_COMMIT` → `CADDY_MWCACHE_VERSION` to reflect the tag value
- Adds `## v1.4.0` to `dockers/caddy/README.md`, so the image publishes as `ghcr.io/femiwiki/caddy:v1.4.0`

## Context

This is the only step that actually changes the **production** Caddy version — it is set by this Dockerfile's `xcaddy build` arg, not by caddy-mwcache's `go.mod`. caddy-mwcache PR #98 already verified the plugin compiles and tests against Caddy 2.11.4 (which requires Go 1.25).

The `Docker: caddy` workflow builds this image on the PR (amd64 + arm64, no push), so the `xcaddy build v2.11.4` compile is validated by CI here.

On merge, the existing automation opens a follow-up PR to bump the downstream `femiwiki` image to `ghcr.io/femiwiki/caddy:v1.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)