### PR TITLE
refactor(ci): build docker images on native runners with GHA cache

### DIFF
--- a/.github/workflows/docker-caddy.yml
+++ b/.github/workflows/docker-caddy.yml
@@ -11,57 +11,128 @@ on:
       - .github/workflows/docker-caddy.yml
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  docker-image:
+  get-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ver: ${{ steps.version.outputs.ver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - id: version
+        run: echo "ver=$(grep '## v' dockers/caddy/README.md | head -n 1 | cut -d'v' -f2)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
+  build:
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to ghcr.io
         if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: get-version
-        run: echo "ver=$(grep '## v' dockers/caddy/README.md | head -n 1 | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
-      - uses: docker/build-push-action@v6
+      - name: Build ${{ matrix.platform }}
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: '{{ defaultContext }}:dockers/caddy'
-          platforms: linux/amd64,linux/arm64
-          cache-from: ghcr.io/femiwiki/caddy:latest
-          load: false
-          push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-          tags: |
-            ghcr.io/femiwiki/caddy:latest
-            ghcr.io/femiwiki/caddy:${{ steps.get-version.outputs.ver }}
-
-      - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=caddy-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=caddy-${{ matrix.arch }}
+          outputs: ${{ (github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main') && 'type=image,name=ghcr.io/femiwiki/caddy,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+      - name: Export digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+      - name: Upload digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          name: digests-caddy-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    needs: [get-version, build]
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-caddy-*
+          merge-multiple: true
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          VER: ${{ needs.get-version.outputs.ver }}
+        run: |
+          image=ghcr.io/femiwiki/caddy
+          args=()
+          for digest in *; do
+            args+=("${image}@sha256:${digest}")
+          done
+          docker buildx imagetools create \
+            -t "${image}:latest" \
+            -t "${image}:${VER}" \
+            "${args[@]}"
+      - uses: ./.github/actions/add-nev-version-entry-to-changelog
+        with:
+          version: ${{ needs.get-version.outputs.ver }}
           upstream: caddy
           downstream: femiwiki
-
-      - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+      - uses: peter-murray/workflow-application-token-action@d17e3a9a36850ea89f35db16c1067dd2b68ee343 # v4.0.1
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
           application_private_key: ${{ secrets.PAT_APPLICATION_PRIVATE_KEY }}
-
       - name: Create Pull Request
-        id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump femiwiki docker image
-          title: 'femiwiki: Bump caddy docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-caddy-v${{ steps.get-version.outputs.ver }}-femiwiki
+          title: 'femiwiki: Bump caddy docker image to v${{ needs.get-version.outputs.ver }}'
+          branch: bump-caddy-v${{ needs.get-version.outputs.ver }}-femiwiki

--- a/.github/workflows/docker-femiwiki-extensions.yml
+++ b/.github/workflows/docker-femiwiki-extensions.yml
@@ -15,57 +15,57 @@ concurrency:
   group: docker-femiwiki-extensions
   cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
+permissions: {}
+
 jobs:
   docker-image:
-    runs-on: ubuntu-latest
+    # femiwiki-extensions is an amd64-only image, so no arm64/QEMU is needed.
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to ghcr.io
         if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: get-version
-        run: echo "ver=$(grep -m 1 '## v' dockers/femiwiki-extensions/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
-      - uses: docker/build-push-action@v6
+      - id: version
+        run: echo "ver=$(grep -m 1 '## v' dockers/femiwiki-extensions/README.md | cut -d'v' -f2)" >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: '{{ defaultContext }}:dockers/femiwiki-extensions'
           platforms: linux/amd64
-          cache-from: ghcr.io/femiwiki/femiwiki-extensions:latest
-          load: false
+          cache-from: type=gha,scope=femiwiki-extensions
+          cache-to: type=gha,mode=max,scope=femiwiki-extensions
           push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/femiwiki/femiwiki-extensions:latest
-            ghcr.io/femiwiki/femiwiki-extensions:${{ steps.get-version.outputs.ver }}
-
+            ghcr.io/femiwiki/femiwiki-extensions:${{ steps.version.outputs.ver }}
       - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          version: ${{ steps.version.outputs.ver }}
           upstream: femiwiki-extensions
           downstream: femiwiki
-
-      - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+      - uses: peter-murray/workflow-application-token-action@d17e3a9a36850ea89f35db16c1067dd2b68ee343 # v4.0.1
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
           application_private_key: ${{ secrets.PAT_APPLICATION_PRIVATE_KEY }}
-
       - name: Create Pull Request
-        id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-        uses: peter-evans/create-pull-request@v7
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump femiwiki-extensions docker image
-          title: 'femiwiki: Bump femiwiki-extensions docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-femiwiki-extensions-v${{ steps.get-version.outputs.ver }}-femiwiki
+          title: 'femiwiki: Bump femiwiki-extensions docker image to v${{ steps.version.outputs.ver }}'
+          branch: bump-femiwiki-extensions-v${{ steps.version.outputs.ver }}-femiwiki

--- a/.github/workflows/docker-femiwiki.yml
+++ b/.github/workflows/docker-femiwiki.yml
@@ -15,41 +15,37 @@ concurrency:
   group: docker-femiwiki
   cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
+permissions: {}
+
 jobs:
-  docker-image:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Edit configuration
         run: |
           mv dockers/femiwiki/LocalSettings.php development
           mv dockers/femiwiki/Hotfix.php development
           sed -i -r 's~ghcr\.io\/femiwiki\/femiwiki:.+~ghcr\.io\/femiwiki\/femiwiki:docker-test~' compose.yml
-
-      - run: |
-          echo "version=$(date +%Y-%m-%dT%H-%M)-$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
-        id: version
-
-      - uses: docker/build-push-action@v6
+      - name: Build amd64 image for testing
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: '{{ defaultContext }}:dockers/femiwiki'
           platforms: linux/amd64
-          cache-from: ghcr.io/femiwiki/femiwiki:latest
-          cache-to: mode=max,type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha,scope=femiwiki-amd64
+          cache-to: type=gha,mode=max,scope=femiwiki-amd64
           load: true
           push: false
           tags: ghcr.io/femiwiki/femiwiki:docker-test
-
       - name: Initialize docker swarm and start services
         run: |
           docker swarm init
           docker stack deploy -c compose.yml mediawiki
-
       - name: Access 127.0.0.1:8080 until success
         timeout-minutes: 2
         run: |
@@ -66,7 +62,6 @@ jobs:
           URL="127.0.0.1:8080/w/Special:MathStatus"
           until curl -sLfo /dev/null "$URL"; do
             sleep 1; done
-
       - name: backup of failure
         if: ${{ failure() }}
         timeout-minutes: 1
@@ -77,42 +72,106 @@ jobs:
           curl -Lv "$URL" && echo "VE success" || echo "VE failure"
           URL="127.0.0.1:8080/w/Special:MathStatus"
           curl -Lv "$URL" && echo "Math success" || echo "Math failure"
-
       - name: backup of failure - docker status
         if: ${{ failure() }}
         run: |
           docker ps;
           for s in $(docker service ls -q ); do docker service ps "$s"; done
           docker container ps;
-
       - name: backup of failure - docker logs
         if: ${{ failure() }}
         run: |
           for s in $(docker service ls -q ); do docker service logs "$s"; done
-
       - name: Check if the container is still up
         run: test "$(docker service ps -qf 'desired-state=Running' -f 'desired-state=Ready' mediawiki_fastcgi)"
       - name: Try to access the mediawiki
         run: curl -sSLvo /dev/null 127.0.0.1:8080 || docker service logs mediawiki_fastcgi
 
-      - uses: docker/login-action@v3
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to ghcr.io
         if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build a multi-platform docker image and push
-        uses: docker/build-push-action@v6
+      - name: Build ${{ matrix.platform }}
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          context: '{{defaultContext}}:dockers/femiwiki'
-          platforms: linux/amd64,linux/arm64
-          cache-from: |
-            ghcr.io/femiwiki/femiwiki:latest
-            type=local,src=/tmp/.buildx-cache
-          cache-to: mode=max,type=inline
-          load: false
-          push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-          tags: |
-            ghcr.io/femiwiki/femiwiki:latest
-            ghcr.io/femiwiki/femiwiki:${{ steps.version.outputs.version }}
+          context: '{{ defaultContext }}:dockers/femiwiki'
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=femiwiki-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=femiwiki-${{ matrix.arch }}
+          outputs: ${{ (github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main') && 'type=image,name=ghcr.io/femiwiki/femiwiki,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+      - name: Export digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+      - name: Upload digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-femiwiki-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    needs: [test, build]
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - id: version
+        run: echo "version=$(date +%Y-%m-%dT%H-%M)-$(echo "$GITHUB_SHA" | cut -c1-8)" >> "$GITHUB_OUTPUT"
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-femiwiki-*
+          merge-multiple: true
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          image=ghcr.io/femiwiki/femiwiki
+          args=()
+          for digest in *; do
+            args+=("${image}@sha256:${digest}")
+          done
+          docker buildx imagetools create \
+            -t "${image}:latest" \
+            -t "${image}:${VERSION}" \
+            "${args[@]}"

--- a/.github/workflows/docker-mediawiki.yml
+++ b/.github/workflows/docker-mediawiki.yml
@@ -11,57 +11,128 @@ on:
       - .github/workflows/docker-mediawiki.yml
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  docker-image:
+  get-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ver: ${{ steps.version.outputs.ver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - id: version
+        run: echo "ver=$(grep -m 1 '## v' dockers/mediawiki/README.md | cut -d'v' -f2)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
+  build:
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to ghcr.io
         if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: get-version
-        run: echo "ver=$(grep -m 1 '## v' dockers/mediawiki/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
-      - uses: docker/build-push-action@v6
+      - name: Build ${{ matrix.platform }}
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: '{{ defaultContext }}:dockers/mediawiki'
-          platforms: linux/amd64,linux/arm64
-          cache-from: ghcr.io/femiwiki/mediawiki:latest
-          load: false
-          push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-          tags: |
-            ghcr.io/femiwiki/mediawiki:latest
-            ghcr.io/femiwiki/mediawiki:${{ steps.get-version.outputs.ver }}
-
-      - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=mediawiki-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=mediawiki-${{ matrix.arch }}
+          outputs: ${{ (github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main') && 'type=image,name=ghcr.io/femiwiki/mediawiki,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+      - name: Export digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+      - name: Upload digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          name: digests-mediawiki-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    needs: [get-version, build]
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-mediawiki-*
+          merge-multiple: true
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          VER: ${{ needs.get-version.outputs.ver }}
+        run: |
+          image=ghcr.io/femiwiki/mediawiki
+          args=()
+          for digest in *; do
+            args+=("${image}@sha256:${digest}")
+          done
+          docker buildx imagetools create \
+            -t "${image}:latest" \
+            -t "${image}:${VER}" \
+            "${args[@]}"
+      - uses: ./.github/actions/add-nev-version-entry-to-changelog
+        with:
+          version: ${{ needs.get-version.outputs.ver }}
           upstream: mediawiki
           downstream: femiwiki
-
-      - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+      - uses: peter-murray/workflow-application-token-action@d17e3a9a36850ea89f35db16c1067dd2b68ee343 # v4.0.1
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
           application_private_key: ${{ secrets.PAT_APPLICATION_PRIVATE_KEY }}
-
       - name: Create Pull Request
-        id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump mediawiki docker image
-          title: 'femiwiki: Bump mediawiki docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-mediawiki-v${{ steps.get-version.outputs.ver }}-femiwiki
+          title: 'femiwiki: Bump mediawiki docker image to v${{ needs.get-version.outputs.ver }}'
+          branch: bump-mediawiki-v${{ needs.get-version.outputs.ver }}-femiwiki

--- a/.github/workflows/docker-php-fpm.yml
+++ b/.github/workflows/docker-php-fpm.yml
@@ -11,63 +11,134 @@ on:
       - .github/workflows/docker-php-fpm.yml
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  docker-image:
+  get-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ver: ${{ steps.version.outputs.ver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - id: version
+        run: echo "ver=$(grep -m 1 '## v' dockers/php-fpm/README.md | cut -d'v' -f2)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
+  build:
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to ghcr.io
         if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: get-version
-        run: echo "ver=$(grep -m 1 '## v' dockers/php-fpm/README.md | cut -d'v' -f2)" >> $GITHUB_OUTPUT
-
-      - uses: docker/build-push-action@v6
+      - name: Build ${{ matrix.platform }}
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: '{{ defaultContext }}:dockers/php-fpm'
-          platforms: linux/amd64,linux/arm64
-          cache-from: ghcr.io/femiwiki/php-fpm:latest
-          load: false
-          push: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-          tags: |
-            ghcr.io/femiwiki/php-fpm:latest
-            ghcr.io/femiwiki/php-fpm:${{ steps.get-version.outputs.ver }}
-
-      - uses: ./.github/actions/add-nev-version-entry-to-changelog
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=php-fpm-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=php-fpm-${{ matrix.arch }}
+          outputs: ${{ (github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main') && 'type=image,name=ghcr.io/femiwiki/php-fpm,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+      - name: Export digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+      - name: Upload digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          version: ${{ steps.get-version.outputs.ver }}
+          name: digests-php-fpm-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    needs: [get-version, build]
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-php-fpm-*
+          merge-multiple: true
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          VER: ${{ needs.get-version.outputs.ver }}
+        run: |
+          image=ghcr.io/femiwiki/php-fpm
+          args=()
+          for digest in *; do
+            args+=("${image}@sha256:${digest}")
+          done
+          docker buildx imagetools create \
+            -t "${image}:latest" \
+            -t "${image}:${VER}" \
+            "${args[@]}"
+      - uses: ./.github/actions/add-nev-version-entry-to-changelog
+        with:
+          version: ${{ needs.get-version.outputs.ver }}
           upstream: php-fpm
           downstream: mediawiki
-
-      - uses: peter-murray/workflow-application-token-action@v4
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
+      - uses: peter-murray/workflow-application-token-action@d17e3a9a36850ea89f35db16c1067dd2b68ee343 # v4.0.1
         id: get_workflow_token
         with:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
           application_private_key: ${{ secrets.PAT_APPLICATION_PRIVATE_KEY }}
-
       - name: Create Pull Request
         id: create-pull-request
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
           commit-message: Bump php-fpm docker image
-          title: 'mediawiki: Bump php-fpm docker image to v${{ steps.get-version.outputs.ver }}'
-          branch: bump-php-fpm-v${{ steps.get-version.outputs.ver }}-femiwiki
-
+          title: 'mediawiki: Bump php-fpm docker image to v${{ needs.get-version.outputs.ver }}'
+          branch: bump-php-fpm-v${{ needs.get-version.outputs.ver }}-femiwiki
       - name: Enable Pull Request Automerge
-        if: ${{ github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main' }}
-        run: gh pr merge --squash --auto ${{ steps.create-pull-request.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "$PR_NUMBER"


### PR DESCRIPTION
Speeds up the multi-platform Docker image builds by using **native amd64 + arm64 runners** instead of QEMU emulation, and caching layers in the **GitHub Actions cache** (`type=gha`).

Closes #503.
Supersedes #990 (which used the non-existent `ubuntu-latest-arm64` runner label and the non-existent `replace()` expression function, and did not use the GHA cache).

## Approach

- **build** job runs a matrix over `linux/amd64` on `ubuntu-24.04` and `linux/arm64` on `ubuntu-24.04-arm` (free native ARM runners for public repos). No more `docker/setup-qemu-action`.
- Layer cache via `cache-from/to: type=gha` scoped per platform.
- On `main`, each arch is pushed **by digest** and a **push-manifest** job combines them into the `:latest` / `:<version>` manifest list (Docker's recommended multi-runner pattern). On PRs both arches build `cache-only` to validate without pushing.
- Workflows are SHA-pinned and use least-privilege `permissions:` so they pass the zizmor gate.

## Rollout

Landing incrementally, validating the pattern on `docker-caddy` first (fastest to iterate), then applying the same structure to `docker-femiwiki`, `docker-mediawiki`, `docker-php-fpm`, and `docker-femiwiki-extensions` in this PR before merge. The MediaWiki images keep their amd64 swarm smoke-test job.

> Once merged, the open zizmor-hardening PR (#1021) and other branches touching these workflows will be rebased on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)