### PR TITLE
refactor(ci): only run docker builds on main pushes

### DIFF
--- a/.github/workflows/docker-caddy.yml
+++ b/.github/workflows/docker-caddy.yml
@@ -2,13 +2,12 @@ name: 'Docker: caddy'
 
 on:
   push:
-    paths:
+    branches: [main]
+    paths: &paths
       - 'dockers/caddy/**'
       - .github/workflows/docker-caddy.yml
   pull_request:
-    paths:
-      - 'dockers/caddy/**'
-      - .github/workflows/docker-caddy.yml
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/docker-femiwiki-extensions.yml
+++ b/.github/workflows/docker-femiwiki-extensions.yml
@@ -2,13 +2,12 @@ name: 'Docker: femiwiki-extensions'
 
 on:
   push:
-    paths:
+    branches: [main]
+    paths: &paths
       - 'dockers/femiwiki-extensions/**'
       - .github/workflows/docker-femiwiki-extensions.yml
   pull_request:
-    paths:
-      - 'dockers/femiwiki-extensions/**'
-      - .github/workflows/docker-femiwiki-extensions.yml
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker-femiwiki.yml
+++ b/.github/workflows/docker-femiwiki.yml
@@ -2,13 +2,12 @@ name: 'Docker: femiwiki'
 
 on:
   push:
-    paths:
+    branches: [main]
+    paths: &paths
       - 'dockers/femiwiki/**'
       - .github/workflows/docker-femiwiki.yml
   pull_request:
-    paths:
-      - 'dockers/femiwiki/**'
-      - .github/workflows/docker-femiwiki.yml
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker-mediawiki.yml
+++ b/.github/workflows/docker-mediawiki.yml
@@ -2,13 +2,12 @@ name: 'Docker: mediawiki'
 
 on:
   push:
-    paths:
+    branches: [main]
+    paths: &paths
       - 'dockers/mediawiki/**'
       - .github/workflows/docker-mediawiki.yml
   pull_request:
-    paths:
-      - 'dockers/mediawiki/**'
-      - .github/workflows/docker-mediawiki.yml
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/docker-php-fpm.yml
+++ b/.github/workflows/docker-php-fpm.yml
@@ -2,13 +2,12 @@ name: 'Docker: php-fpm'
 
 on:
   push:
-    paths:
+    branches: [main]
+    paths: &paths
       - 'dockers/php-fpm/**'
       - .github/workflows/docker-php-fpm.yml
   pull_request:
-    paths:
-      - 'dockers/php-fpm/**'
-      - .github/workflows/docker-php-fpm.yml
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Follow-up to #1022.

Currently each `docker-*` workflow triggers on `push` (any branch) **and** `pull_request`, so pushing to a PR branch starts two runs of the same build. This restricts `push` to `branches: [main]` — the `pull_request` event already covers PR branches, so feature-branch pushes now run once.

The identical `push`/`pull_request` path filters are de-duplicated with a YAML anchor:

```yaml
on:
  push:
    branches: [main]
    paths: &paths
      - 'dockers/caddy/**'
      - .github/workflows/docker-caddy.yml
  pull_request:
    paths: *paths
  workflow_dispatch:
```

`if: github.ref == 'refs/heads/main'` guards are unchanged (still gate publishing). Prettier preserves the anchors and the files stay zizmor-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)