### PR TITLE
fix: run the block responders ahead of mwcache

### DIFF
--- a/dockers/femiwiki/Caddyfile
+++ b/dockers/femiwiki/Caddyfile
@@ -4,7 +4,7 @@
 
 	order mwcache before rewrite
 	# NOTE: See @filter for the further details
-	order respond before rewrite
+	order respond before mwcache
 }
 femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
 	tls {


### PR DESCRIPTION
Effective order today, per `parseOptOrder` in `caddyconfig/httpcaddyfile/options.go` — `order mwcache before rewrite` claims the slot first, so `order respond before rewrite` lands behind it:

```
… → mwcache → respond → rewrite → …
```

caddytest against this exact Caddyfile:

```
before   ClaudeBot, cached URL   -> 200
         ClaudeBot, uncached URL -> 403
after    ClaudeBot, cached URL   -> 403
```

Same bypass applies to `@block_cidr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX)_