### PR TITLE
fix: compress after the cache, not before it

### DIFF
--- a/dockers/femiwiki/Caddyfile
+++ b/dockers/femiwiki/Caddyfile
@@ -5,6 +5,7 @@
 	order mwcache before rewrite
 	# NOTE: See @filter for the further details
 	order respond before mwcache
+	order encode before mwcache
 }
 femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
 	tls {


### PR DESCRIPTION
`encode` sits after `rewrite` in Caddy's default order, so it runs inside mwcache's response recorder and the gzip body plus `Content-Encoding: gzip` is what gets stored. The cache key is `r.URL.RequestURI()` alone, with no Vary handling.

caddytest against this exact Caddyfile:

```
prime with Accept-Encoding: gzip   -> Content-Encoding: gzip
request with no Accept-Encoding    -> 200, Content-Encoding: gzip
```

After the change the second request gets an identity body.

Stacked on #1046; base retargets to `main` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX)_