### PR TITLE
fix: stop ristretto's internal cost from shrinking the cache to 17 entries

### DIFF
--- a/dockers/femiwiki/Caddyfile
+++ b/dockers/femiwiki/Caddyfile
@@ -19,6 +19,7 @@ femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
 		ristretto {
 			num_counters 10000
 			max_cost 1000
+			ignore_internal_cost true
 			buffer_items 64
 		}
 		purge_acl {


### PR DESCRIPTION
`RistrettoBackend.put` stores every entry with `cost` 1, and ristretto adds `itemSize` (`unsafe.Sizeof(storeItem{})` = 56) unless `IgnoreInternalCost` is set (`ristretto@v0.2.0/cache.go:471`). Real capacity is 1000/57.

```
5000 entries inserted into MaxCost=1000 -> 17 retained
keys-added: 5000  keys-evicted: 4983  cost-added: 285000  hit-ratio: 0.00
```

Production — the main page is cached, an ordinary article is not:

```
/w/페미위키:대문  x-request-id: 539669cff53359cf8874d69d
/w/페미위키:대문  x-request-id: 539669cff53359cf8874d69d
/w/설경구        x-request-id: b32ef97ff7d12cf14c30ce70
/w/설경구        x-request-id: fd9e121cfaf1ee53b06a97ca
```

Stacked on #1047 deliberately: widening the cache while the responders sit behind mwcache would widen the #1046 bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX)_