### PR TITLE
fix: disallow crawling of the locked and anonymous-useless actions

### DIFF
--- a/dockers/femiwiki/robots.txt
+++ b/dockers/femiwiki/robots.txt
@@ -17,8 +17,15 @@ Allow: /*&action=raw
 User-agent: *
 Allow: /api.php?action=mobileview&
 Allow: /femiwiki.com/v1/?doc
+Disallow: /*&action=
+Disallow: /*?action=edit
+Disallow: /*?action=history
+Disallow: /*?action=info
+Disallow: /*?action=raw
 Disallow: /*&diff=
+Disallow: /*?diff=
 Disallow: /*&oldid=
+Disallow: /*?oldid=
 Disallow: /*&direction=
 Disallow: /*&redlink=
 Disallow: /api.php


### PR DESCRIPTION
`$wgActionLockdown` locks `history`, `info` and `raw` to registered users, but the tabs are still in anonymous HTML and robots.txt has no `action=` rule. One article, fetched anonymously:

```
/index.php?title=설경구&action=history
/index.php?title=설경구&action=info
/index.php?title=설경구&action=edit
/index.php?title=설경구&action=watch
```

The refusal is neither cheap nor cacheable:

```
HTTP/2 200
cache-control: no-cache, no-store, max-age=0, must-revalidate
~26 KB of fully rendered skin
```

Existing `/*&diff=` and `/*&oldid=` also miss the forms that put those first. `?action=` is enumerated rather than wildcarded to leave the `api.php` Allow rules untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX)_