### PR TITLE
perf: size opcache to the shipped codebase

### DIFF
--- a/dockers/php-fpm/opcache-recommended.ini
+++ b/dockers/php-fpm/opcache-recommended.ini
@@ -1,7 +1,7 @@
 ; Reference: https://secure.php.net/manual/en/opcache.installation.php
-opcache.memory_consumption=128
-opcache.interned_strings_buffer=8
-opcache.max_accelerated_files=4000
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=32531
 opcache.revalidate_freq=60
 opcache.fast_shutdown=1
 opcache.enable_cli=1


### PR DESCRIPTION
`max_accelerated_files=4000` is rounded up to 7963 by PHP. The extensions and skins layer of the published image alone holds far more:

```
$ tar tzf <layer> | grep -c 'srv/femiwiki.com/.*\.php$'
39308
```

Past the limit opcache stops caching new files and every request recompiles them. 32531 is the next step in PHP's prime table; the file count also puts the compiled footprint well over the 128 MB buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX)_