### PR TITLE
fix: point purge_acl at this VPC's CIDR

### DIFF
--- a/dockers/femiwiki/Caddyfile
+++ b/dockers/femiwiki/Caddyfile
@@ -21,7 +21,7 @@ femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
 			buffer_items 64
 		}
 		purge_acl {
-			10.0.0.0/8
+			172.31.0.0/16
 			127.0.0.1
 		}
 	}

--- a/dockers/femiwiki/Caddyfile
+++ b/dockers/femiwiki/Caddyfile
@@ -22,6 +22,7 @@ femiwiki.com *.femiwiki.com 127.0.0.1:80 localhost:80 {
 		}
 		purge_acl {
 			172.31.0.0/16
+			10.20.0.0/16
 			127.0.0.1
 		}
 	}


### PR DESCRIPTION
Resolves femiwiki/femiwiki#468.

`purge_acl` allowed `10.0.0.0/8`, but this VPC is `172.31.0.0/16` — the same value `container.tf` passes as `WG_BOUNCE_HANDLER_INTERNAL_IPS`. So the ACL never matched the source of a real PURGE, and it granted a range we do not own.

`10.20.0.0/16` is the Seoul VPC femiwiki/femiwiki#482 plans to build. That issue relied on `10.0.0.0/8` covering it; the second commit lists it explicitly instead, so the ACL is ready before the region exists and PURGE is not a cutover step.

Merging only builds an image; production is unchanged until the tag is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX