### PR TITLE
feat: serve a liveness endpoint from the backend role

### DIFF
--- a/dockers/femiwiki/Dockerfile
+++ b/dockers/femiwiki/Dockerfile
@@ -47,7 +47,7 @@ RUN COMPOSER_HOME=/composer /usr/bin/composer update --no-dev --working-dir /srv
 RUN chmod o+w /srv/femiwiki.com/extensions/Widgets/compiled_templates
 
 # Ship femiwiki resources
-COPY --chown=www-data:www-data ["resources", "Caddyfile", "backend.Caddyfile", "robots.txt", "/srv/femiwiki.com/"]
+COPY --chown=www-data:www-data ["resources", "Caddyfile", "backend.Caddyfile", "robots.txt", "healthz-live.php", "/srv/femiwiki.com/"]
 COPY --chown=www-data:www-data ["site-list.xml", "Hotfix.php", "/a/"]
 
 COPY --chown=www-data LocalSettings.php /a/

--- a/dockers/femiwiki/backend.Caddyfile
+++ b/dockers/femiwiki/backend.Caddyfile
@@ -11,6 +11,11 @@
 # until the app tier exists.
 :8080 {
 	root * /srv/femiwiki.com
+
+	# Liveness: proves php-fpm executes PHP, and nothing more. Used by Caddy's
+	# active health checks and the container watchdog.
+	rewrite /healthz-live /healthz-live.php
+
 	php_fastcgi {$FASTCGI_ADDR}
 	file_server
 

--- a/dockers/femiwiki/healthz-live.php
+++ b/dockers/femiwiki/healthz-live.php
@@ -1,0 +1,6 @@
+<?php
+// Liveness only: proves php-fpm executes PHP. Deliberately touches no
+// dependency - a shared database or cache being down affects every instance
+// equally, so failing them all out of the pool helps nobody. Capacity, not
+// health, is what a liveness check answers. See femiwiki/femiwiki#467.
+http_response_code( 200 );


### PR DESCRIPTION
Part of femiwiki/femiwiki#467. Stage A of femiwiki/femiwiki#517. Stacked on #1054.

One line of PHP behind `/healthz-live`, for Caddy's active health checks and the container watchdog. It proves php-fpm executes PHP and deliberately touches nothing else.

That last part is the whole design. An earlier version of this PR checked the database and the object cache, following #467 as written. Wikimedia does the opposite: their liveness probe checks only that the port is open, and readiness fetches a `/healthz` that reports whether httpd is up and php-fpm has free worker slots — [How it works](https://wikitech.wikimedia.org/wiki/MediaWiki_On_Kubernetes/How_it_works). Neither touches MySQL.

The reason is that a shared dependency fails every instance at once. Failing them all out of the pool converts a degraded site into no site. A health check that gates *traffic* should answer "can this instance take a request", not "is the wiki healthy".

Dependency checks still belong somewhere — the ASG launch hook, which decides once whether a new instance is good enough to terminate a working one over. That is a different consumer with a different answer, and it does not need a PHP endpoint: `curl` against `api.php?action=query&meta=siteinfo` proves LocalSettings, the database credentials and the schema end to end, and a `printf` into memcached over its text protocol covers the cache. Two lines of shell, run once per launch. That lands with the launch template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code)_