### PR TITLE
feat: add a backend-role Caddy config for the app tier

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,9 +41,9 @@ jobs:
           persist-credentials: false
       - name: Format caddyfile
         run: |
-          for CADDYFILE_PATH in **/Caddyfile; do
-            docker run -v $(dirname $(realpath $CADDYFILE_PATH)):/srv caddy \
-              caddy fmt --diff
+          find . -name Caddyfile -o -name '*.Caddyfile' | while read -r CADDYFILE_PATH; do
+            docker run -v "$(dirname "$(realpath "$CADDYFILE_PATH")")":/srv caddy \
+              caddy fmt --diff "/srv/$(basename "$CADDYFILE_PATH")"
           done
 
   etc-lint:

--- a/dockers/femiwiki/Dockerfile
+++ b/dockers/femiwiki/Dockerfile
@@ -47,7 +47,7 @@ RUN COMPOSER_HOME=/composer /usr/bin/composer update --no-dev --working-dir /srv
 RUN chmod o+w /srv/femiwiki.com/extensions/Widgets/compiled_templates
 
 # Ship femiwiki resources
-COPY --chown=www-data:www-data ["resources", "Caddyfile", "robots.txt", "/srv/femiwiki.com/"]
+COPY --chown=www-data:www-data ["resources", "Caddyfile", "backend.Caddyfile", "robots.txt", "/srv/femiwiki.com/"]
 COPY --chown=www-data:www-data ["site-list.xml", "Hotfix.php", "/a/"]
 
 COPY --chown=www-data LocalSettings.php /a/

--- a/dockers/femiwiki/backend.Caddyfile
+++ b/dockers/femiwiki/backend.Caddyfile
@@ -1,0 +1,20 @@
+# Backend role for the ASG app tier (femiwiki/femiwiki#476).
+#
+# Plain HTTP, no TLS, no mwcache, no crawler blocking - the edge owns all of
+# that. Reachable only from the edge security group. Run with:
+#   caddy run --config /srv/femiwiki.com/backend.Caddyfile
+#
+# Static assets are served here, next to the PHP that expects them, so a
+# rolling deploy never pairs one version's assets with another's code.
+#
+# The single-box setup does not use this file, so shipping it changes nothing
+# until the app tier exists.
+:8080 {
+	root * /srv/femiwiki.com
+	php_fastcgi {$FASTCGI_ADDR}
+	file_server
+
+	log {
+		format json
+	}
+}


### PR DESCRIPTION
Stage A of femiwiki/femiwiki#517.

php-fpm speaks FastCGI, but the ASG app tier has to speak plain HTTP on `:8080` — the edge proxies to it and health-checks it. So the app role needs its own Caddy config: no TLS, no `mwcache`, no crawler blocking, since the edge owns all of that.

`file_server` is here on purpose. MediaWiki keeps PHP and static assets in one tree, so serving assets from the *edge* would pin the edge's tree to a single code version — impossible during a rolling deploy, where two app versions are live at once and the edge has only one tree. Each instance serving its own assets next to its own PHP keeps them matched.

Separate file rather than a `:8080` block in `Caddyfile`: the current single-box `http` container runs with `network_mode = "host"`, so a shared-config listener would really bind 8080 in production.

Named `backend.Caddyfile` so editor tooling, which keys off the `.caddyfile` extension, still recognises it. The `caddy-fmt` job globbed `**/Caddyfile` and would have skipped any new config whatever we called it, so it now finds both forms via `find` — and passes the filename explicitly, since `caddy fmt` with no argument only ever reads `Caddyfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code)_