### PR TITLE
perf: build the localisation cache at boot, before serving

### DIFF
--- a/dockers/femiwiki/postrun
+++ b/dockers/femiwiki/postrun
@@ -1,2 +1,10 @@
 #!/bin/bash
 set -euxo pipefail; IFS=$'\n\t'
+
+# Build the localisation cache before php-fpm accepts traffic, so the first
+# request does not pay for merging every i18n/*.json in core and every
+# extension. Runs here rather than at image-build time because LocalSettings.php
+# reaches the database during bootstrap - an $wgExtensionFunctions entry calls
+# SpecialPage::getTitleFor - so no MediaWiki bootstrap works without a server.
+# See femiwiki/femiwiki#472.
+php /srv/femiwiki.com/maintenance/rebuildLocalisationCache.php --quiet


### PR DESCRIPTION
Resolves femiwiki/femiwiki#472's localisation-cache half. Stage A of femiwiki/femiwiki#517.

A cold instance builds the localisation cache on its first request — merging every `i18n/*.json` in core and every extension, resolving fallback chains, magic words, namespace names. Under an ASG that lands on a user's request, on an instance the launch hook has already declared ready.

Moving it into `postrun` puts it before php-fpm accepts anything, so the cost is paid inside the boot window the launch hook already waits through.

**It cannot be baked into the image, which is where this started.** `rebuildLocalisationCache.php --no-database` makes the *script* not require a database, but `LocalSettings.php` reaches one during bootstrap regardless: an `$wgExtensionFunctions` entry calls `SpecialPage::getTitleFor( 'UploadWizard' )`, which walks the `SpecialPage_initList` hook into GrowthExperiments' `WikiPageConfig` and connects. CI caught it — no MediaWiki bootstrap works in this image without a reachable database. Making that lazy so the cache can be baked is femiwiki/femiwiki#518.

`postrun` rather than `prerun`: `run` copies `LocalSettings.php` into the webroot between the two, so at `prerun` there is nothing to bootstrap.

Cost: every container start now pays this, including restarts on the current single box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code)_