### PR TITLE
build: bake the FastCGI liveness probe into the image

### DIFF
--- a/dockers/femiwiki/Dockerfile
+++ b/dockers/femiwiki/Dockerfile
@@ -52,6 +52,19 @@ COPY --chown=www-data:www-data ["site-list.xml", "Hotfix.php", "/a/"]
 
 COPY --chown=www-data LocalSettings.php /a/
 
+# php-fpm liveness probe, from Wikimedia's production images. Pinned to the
+# same commit the deploy already uses, so baking it in changes no behaviour -
+# bumping it upstream is a separate, visible change.
+#
+# It is baked rather than fetched at runtime because the container healthcheck
+# currently curls these from raw.githubusercontent.com with retries=0, so a
+# fresh container restart-loops whenever that fetch fails.
+ARG WMF_PRODUCTION_IMAGES=ad68c7cb62e4e01436ab3a34fb961fe8034c2cce
+RUN mkdir -p /srv/fcgi-check &&\
+    BASE="https://github.com/wikimedia/operations-docker-images-production-images/raw/${WMF_PRODUCTION_IMAGES}/images/php/common/fpm/live-test" &&\
+    curl -fSL "$BASE/AdoyFastCgiClient.php" -o /srv/fcgi-check/AdoyFastCgiClient.php &&\
+    curl -fSL "$BASE/fcgi-probe.php" -o /srv/fcgi-check/fcgi-probe.php
+
 EXPOSE 80
 EXPOSE 443
 EXPOSE 9000


### PR DESCRIPTION
Stage A of femiwiki/femiwiki#517.

The container healthcheck curls `AdoyFastCgiClient.php` and `fcgi-probe.php` from `raw.githubusercontent.com` **at runtime**, with `retries = 0`. A fresh container whose fetch fails restart-loops — which is precisely the situation an ASG creates, repeatedly, on a boot path where nothing is watching.

Baked instead, pinned to `ad68c7cb62e4e01436ab3a34fb961fe8034c2cce` — the same commit femiwiki/nomad and `infra`'s healthcheck already use. That is deliberate: it is the probe running in production today, so baking it in changes no behaviour. Bumping to a newer upstream commit is a separate, visible change, or a failure could be either one.

Pinned rather than tracking HEAD because the fetch has moved into the build: unpinned, two builds of the same commit would produce different images, and an upstream change to the probe would arrive silently instead of as a reviewable line here.

Does not touch the healthcheck itself — `infra`'s `container.tf` still runs its own fetch, whose guards (`if [ ! -z /srv/fcgi-check/... ]`, always true for a non-empty string) mean it re-downloads every time regardless. Simplifying that to just run the baked probe belongs with the infra change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX)_