### PR TITLE
feat: add a poolcounter image

### DIFF
--- a/.github/workflows/docker-poolcounter.yml
+++ b/.github/workflows/docker-poolcounter.yml
@@ -1,0 +1,119 @@
+name: 'Docker: poolcounter'
+
+on:
+  push:
+    branches: [main]
+    paths: &paths
+      - 'dockers/poolcounter/**'
+      - .github/workflows/docker-poolcounter.yml
+  pull_request:
+    paths: *paths
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ver: ${{ steps.version.outputs.ver }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - id: version
+        run: echo "ver=$(grep '## v' dockers/poolcounter/README.md | head -n 1 | cut -d'v' -f2)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: get-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to ghcr.io
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build ${{ matrix.platform }}
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: '{{ defaultContext }}:dockers/poolcounter'
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=poolcounter-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=poolcounter-${{ matrix.arch }}
+          outputs: ${{ (github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main') && 'type=image,name=ghcr.io/femiwiki/poolcounter,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+      - name: Export digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+      - name: Upload digest
+        if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-poolcounter-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    needs: [get-version, build]
+    if: github.repository_owner == 'femiwiki' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-poolcounter-*
+          merge-multiple: true
+      - name: Log in to ghcr.io
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          VER: ${{ needs.get-version.outputs.ver }}
+        run: |
+          image=ghcr.io/femiwiki/poolcounter
+          args=()
+          for digest in *; do
+            args+=("${image}@sha256:${digest}")
+          done
+          docker buildx imagetools create \
+            -t "${image}:latest" \
+            -t "${image}:${VER}" \
+            "${args[@]}"

--- a/dockers/poolcounter/Dockerfile
+++ b/dockers/poolcounter/Dockerfile
@@ -1,0 +1,17 @@
+FROM --platform=$TARGETPLATFORM debian:trixie-slim
+
+# poolcounterd is packaged in Debian proper, built for arm64 among others, so
+# there is nothing to compile and security updates arrive with the base image.
+RUN apt-get update &&\
+    apt-get install -y --no-install-recommends poolcounter &&\
+    rm -rf /var/lib/apt/lists/*
+
+USER nobody
+
+EXPOSE 7531
+
+# -l is the only option poolcounterd takes; without it the daemon binds
+# localhost only, which is no use to backends on other hosts. Matching
+# Debian's own unit here - the security group is what limits who can reach it.
+ENTRYPOINT ["/usr/bin/poolcounterd"]
+CMD ["-l", "0.0.0.0"]

--- a/dockers/poolcounter/README.md
+++ b/dockers/poolcounter/README.md
@@ -1,0 +1,11 @@
+# poolcounter
+
+[PoolCounter](https://www.mediawiki.org/wiki/PoolCounter), the lock daemon that
+stops MediaWiki parsing the same page in several processes at once. There is no
+source to build: Debian packages it, so this only installs that package.
+
+Listens on 7531. `$wgPoolCounterConf` points at it.
+
+## v1.0.0
+
+- poolcounter 1.2.0-1 from Debian trixie


### PR DESCRIPTION
Resolves femiwiki/femiwiki#469's packaging half. Stage A of femiwiki/femiwiki#517.

`$wgPoolCounterConf` is unset today, so MediaWiki falls back to a no-op local counter that coordinates nothing across processes or instances. Under an ASG that gets worse: several cold instances can parse the same Lua-heavy page at once, right when capacity is lowest.

**There is nothing to compile.** `poolcounter` is packaged in Debian proper — 1.2.0-1 in trixie, built for arm64 among seven other architectures — so this installs the distribution's build and picks up security updates with the base image. `#469` assumed a source build from `mediawiki/services/poolcounter`; it is not needed.

`-l 0.0.0.0` matches Debian's own systemd unit. Without it `poolcounterd` binds localhost only, which is no use to backends on other hosts; the security group is what limits who can reach 7531. It is the only option the daemon takes.

The workflow is `docker-caddy.yml`'s, minus its tail. That tail opens a PR bumping the reference in `dockers/femiwiki/Dockerfile`, which makes sense for images the femiwiki image is built `FROM` — `caddy`, `mediawiki`, `php-fpm`, `femiwiki-extensions`. poolcounter runs as its own container and is referenced from `infra`, so there is no reference here to bump, and `push-manifest` drops to `contents: read` accordingly.

Not wired up: `$wgPoolCounterConf` and the container itself land with the edge box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKxDdz9NvaC2Caxe7QLxtX)_